### PR TITLE
Speed up CI by compiling with -j6 and run tests with -j100 or -j12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,7 +123,7 @@ jobs:
             ${ProtonCMakeExtraArgs}
 
       - name: qpid-proton cmake build/install
-        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} -t install
+        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} -t install --parallel 6
 
       - name: Display ccache stats
         run: ccache -s
@@ -139,7 +139,7 @@ jobs:
             ${RouterCMakeExtraArgs}
 
       - name: skupper-router cmake build/install
-        run: cmake --build "${RouterBuildDir}" --config ${BuildType} -t install
+        run: cmake --build "${RouterBuildDir}" --config ${BuildType} -t install --parallel 6
 
       - name: Display ccache stats
         run: ccache -s
@@ -221,7 +221,7 @@ jobs:
         working-directory: ${{env.RouterBuildDir}}
         run: |
           ulimit -c unlimited
-          ctest --timeout 1200 -C ${BuildType} -V -T Test --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j2 ${{env.RouterCTestExtraArgs}}
+          ctest --timeout 1200 -C ${BuildType} -V -T Test --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j100 ${{env.RouterCTestExtraArgs}}
 
       - name: Upload test results
         uses: actions/upload-artifact@v2
@@ -390,7 +390,7 @@ jobs:
             ${ProtonCMakeExtraArgs}
 
       - name: qpid-proton cmake build/install
-        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} --target install
+        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} --target install --parallel 6
 
       - name: Display ccache stats
         run: ccache -s
@@ -413,7 +413,7 @@ jobs:
             ${RouterCMakeExtraArgs} -DQD_ENABLE_ASSERTIONS=${RouterCMakeAsserts}
 
       - name: skupper-router cmake build/install
-        run: cmake --build "${RouterBuildDir}" --config ${BuildType} --target install
+        run: cmake --build "${RouterBuildDir}" --config ${BuildType} --target install --parallel 6
 
       - name: Display ccache stats
         run: ccache -s
@@ -446,7 +446,7 @@ jobs:
         working-directory: ${{env.RouterBuildDir}}
         run: |
           ulimit -c unlimited
-          ctest --timeout 1200 -C ${BuildType} -V -T Test --output-on-failure --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j2 ${{env.RouterCTestExtraArgs}}
+          ctest --timeout 1200 -C ${BuildType} -V -T Test --output-on-failure --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j12 ${{env.RouterCTestExtraArgs}}
 
       - name: Upload test results
         uses: actions/upload-artifact@v2
@@ -559,7 +559,7 @@ jobs:
             ${RouterCMakeExtraArgs}
 
       - name: CMake build for docs
-        run: cmake --build "${RouterBuildDir}" -t docs
+        run: cmake --build "${RouterBuildDir}" -t docs --parallel 6
 
       - name: Store the rendered user-guide
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
So, @ted-ross says `-j12`? Phew! :100: 

I am only half-serious about this, but there actually is some merit to these crazy parallel settings.

The downsides are obvious: tests fail more and logs are a mess.

But the upside is that the same tests tend to fail more, over and over again, so they show themselves as the least reliable tests from the whole bunch, and can be fixed. Also, the CI does run a little bit faster, though not by all that much.

The -j6 for compilations is interesting, though. Most of the compilation is essentially fetching stuff from ccache, so there it does make sense to initiate more fetches in parallel. When an actual compilation needs to happen, it will be arrived at faster. Dispatch will "compile" this way in about a second!.

Edit: looking at the durations also shows my folly in doing the split compile and test jobs for Ubuntu. The compressing of the artifacts takes longer than ccache restore and the actual build.

Edit Edit: the natural continuation in this direction would be to run every test multiple times