### PR TITLE
DISPATCH-2144 Fatal Python error: _PyMem_DebugMalloc: Python memory allocator called without holding the GIL (#1495)

### DIFF
--- a/src/python_embedded.c
+++ b/src/python_embedded.c
@@ -57,15 +57,22 @@ void qd_python_initialize(qd_dispatch_t *qd, const char *python_pkgdir)
     if (python_pkgdir)
         dispatch_python_pkgdir = PyUnicode_FromString(python_pkgdir);
 
-    qd_python_lock_state_t ls = qd_python_lock();
     Py_Initialize();
+#if PY_VERSION_HEX < 0x03070000
+    PyEval_InitThreads(); // necessary for Python 3.6 and older versions
+#endif
     qd_python_setup();
-    qd_python_unlock(ls);
+    PyEval_SaveThread(); // drop the Python GIL; we will reacquire it in other threads as needed
+    qd_python_lock_state_t lk = qd_python_lock();
+    qd_python_setup();
+    qd_python_unlock(lk);
 }
 
 
 void qd_python_finalize(void)
 {
+    (void) PyGILState_Ensure(); // not qd_python_lock(), because that function has to be paired with an _unlock
+
     sys_mutex_free(ilock);
     Py_DECREF(dispatch_module);
     dispatch_module = 0;
@@ -892,11 +899,12 @@ qd_python_lock_state_t qd_python_lock(void)
 {
     sys_mutex_lock(ilock);
     lock_held = true;
-    return 0;
+    return PyGILState_Ensure();
 }
 
 void qd_python_unlock(qd_python_lock_state_t lock_state)
 {
+    PyGILState_Release(lock_state);
     lock_held = false;
     sys_mutex_unlock(ilock);
 }

--- a/src/python_embedded.c
+++ b/src/python_embedded.c
@@ -27,7 +27,6 @@
 #include "qpid/dispatch/error.h"
 #include "qpid/dispatch/log.h"
 #include "qpid/dispatch/router.h"
-#include "qpid/dispatch/threading.h"
 
 #include <ctype.h>
 
@@ -39,8 +38,6 @@
 //===============================================================================
 
 static qd_dispatch_t   *dispatch   = 0;
-static sys_mutex_t     *ilock      = 0;
-static bool             lock_held  = false;
 static qd_log_source_t *log_source = 0;
 static PyObject        *dispatch_module = 0;
 static PyObject        *message_type = 0;
@@ -53,7 +50,6 @@ void qd_python_initialize(qd_dispatch_t *qd, const char *python_pkgdir)
 {
     log_source = qd_log_source("PYTHON");
     dispatch = qd;
-    ilock = sys_mutex();
     if (python_pkgdir)
         dispatch_python_pkgdir = PyUnicode_FromString(python_pkgdir);
 
@@ -63,17 +59,13 @@ void qd_python_initialize(qd_dispatch_t *qd, const char *python_pkgdir)
 #endif
     qd_python_setup();
     PyEval_SaveThread(); // drop the Python GIL; we will reacquire it in other threads as needed
-    qd_python_lock_state_t lk = qd_python_lock();
-    qd_python_setup();
-    qd_python_unlock(lk);
 }
 
 
 void qd_python_finalize(void)
 {
-    (void) PyGILState_Ensure(); // not qd_python_lock(), because that function has to be paired with an _unlock
+    (void) qd_python_lock();
 
-    sys_mutex_free(ilock);
     Py_DECREF(dispatch_module);
     dispatch_module = 0;
     PyGC_Collect();
@@ -91,7 +83,7 @@ PyObject *qd_python_module(void)
 
 void qd_python_check_lock(void)
 {
-    assert(lock_held);
+    assert(PyGILState_Check());
 }
 
 
@@ -897,16 +889,12 @@ static void qd_python_setup(void)
 
 qd_python_lock_state_t qd_python_lock(void)
 {
-    sys_mutex_lock(ilock);
-    lock_held = true;
     return PyGILState_Ensure();
 }
 
 void qd_python_unlock(qd_python_lock_state_t lock_state)
 {
     PyGILState_Release(lock_state);
-    lock_held = false;
-    sys_mutex_unlock(ilock);
 }
 
 void qd_json_msgs_init(PyObject **msgs)

--- a/src/server.c
+++ b/src/server.c
@@ -1401,7 +1401,9 @@ void qd_server_free(qd_server_t *qd_server)
     sys_mutex_free(qd_server->lock);
     sys_mutex_free(qd_server->conn_activation_lock);
     sys_cond_free(qd_server->cond);
+    qd_python_lock_state_t ls = qd_python_lock();
     Py_XDECREF((PyObject *)qd_server->py_displayname_obj);
+    qd_python_unlock(ls);
     free(qd_server);
 }
 


### PR DESCRIPTION
The second commit goes further than what is now in Dispatch. It eliminates the lock on the router's side and uses exclusively the Python lock from cpython, i.e. the GIL. There is no reason to maintain two locks, seems to me.