### PR TITLE
Fixed #104: Install only future-proof SASL mechanisms in the final skupper-router image

### DIFF
--- a/.github/scripts/Dockerfile
+++ b/.github/scripts/Dockerfile
@@ -26,7 +26,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
  && dnf config-manager --set-enabled powertools \
  && dnf clean all
 
-RUN dnf -y --setopt=tsflags=nodocs install gcc gcc-c++ make cmake cyrus-sasl-devel cyrus-sasl-plain cyrus-sasl-gssapi cyrus-sasl-md5 openssl-devel libuuid-devel swig wget patch findutils git valgrind libwebsockets-devel python3-devel libnghttp2-devel && dnf clean all -y
+RUN dnf -y --setopt=tsflags=nodocs install gcc gcc-c++ make cmake cyrus-sasl-devel openssl-devel libuuid-devel swig wget patch findutils git valgrind libwebsockets-devel python3-devel libnghttp2-devel && dnf clean all -y
 WORKDIR /build
 COPY . .
 ENV PROTON_VERSION=0.36.0
@@ -45,7 +45,7 @@ RUN dnf -y --setopt=tsflags=nodocs update \
  && dnf clean all
 
 # gdb and valgrind are part of final image as they can be used as debug options for Skupper
-RUN dnf -y --setopt=tsflags=nodocs install glibc cyrus-sasl-lib libuuid openssl gettext hostname iputils libwebsockets-devel libnghttp2 gdb valgrind && dnf clean all
+RUN dnf -y --setopt=tsflags=nodocs install glibc cyrus-sasl-lib cyrus-sasl-plain cyrus-sasl-gssapi libuuid openssl gettext hostname iputils libwebsockets-devel libnghttp2 gdb valgrind && dnf clean all
 
 WORKDIR /
 COPY --from=builder /qpid-proton-image.tar.gz /skupper-router-image.tar.gz /


### PR DESCRIPTION
There is no point in installing the SASL mechanisms in the builder image. There, only the API libraries are useful.

In the final image, install only mechanisms that are available in ubi8 image. The MD5 mechanism is unavailable in ubi8, and it is disabled in FIPS.