### PR TITLE
Speed-up python-checker GHA job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -472,18 +472,11 @@ jobs:
             **/core
 
   python:
-    name: 'Python Checker (${{ matrix.container }}:${{ matrix.containerTag }})'
+    name: 'Python Checker (${{ matrix.os }})'
     runs-on: '${{ matrix.os }}'
     strategy:
       matrix:
         os: [ 'ubuntu-20.04' ]
-        container: [ 'fedora' ]
-        containerTag: [ '35' ]
-
-    container:
-      image: 'quay.io/${{ matrix.container }}/${{ matrix.container }}:${{ matrix.containerTag }}'
-      volumes:
-        - ${{github.workspace}}:${{github.workspace}}
 
     env:
       DispatchBuildDir: ${{github.workspace}}/build
@@ -493,11 +486,19 @@ jobs:
 
     steps:
 
-      - name: Install build dependencies
+      - name: Add Qpid PPA repository
+        if: ${{ runner.os == 'Linux' }}
+        # the `testing` ppa is less likely to be out-of-date
         run: |
-          dnf install -y 'dnf-command(builddep)'
-          dnf builddep -y qpid-dispatch-router --setopt=install_weak_deps=False
-          dnf install -y git tox ninja-build
+          sudo add-apt-repository ppa:qpid/testing && sudo apt-get update
+
+      - name: Install Linux build dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt update; sudo apt install -y libqpid-proton-proactor1-dev python3-qpid-proton libpython3-dev ninja-build
+
+      - name: Install python-checker test dependencies
+        run: python3 -m pip install tox
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Use Ubuntu directly, and install minimal necessary amount of packages.