### PR TITLE
Use Ninja to build container image, because it is faster than make

### DIFF
--- a/.github/scripts/Dockerfile
+++ b/.github/scripts/Dockerfile
@@ -26,7 +26,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
  && dnf config-manager --set-enabled powertools \
  && dnf clean all
 
-RUN dnf -y --setopt=tsflags=nodocs install gcc gcc-c++ make cmake cyrus-sasl-devel openssl-devel libuuid-devel swig wget patch findutils git valgrind libwebsockets-devel python3-devel libnghttp2-devel && dnf clean all -y
+RUN dnf -y --setopt=tsflags=nodocs install gcc gcc-c++ ninja-build cmake cyrus-sasl-devel openssl-devel libuuid-devel swig wget patch findutils git valgrind libwebsockets-devel python3-devel libnghttp2-devel && dnf clean all -y
 WORKDIR /build
 COPY . .
 ENV PROTON_VERSION=0.36.0

--- a/.github/scripts/compile.sh
+++ b/.github/scripts/compile.sh
@@ -42,13 +42,13 @@ tar -zxf qpid-proton.tar.gz -C qpid-proton-src --strip-components 1
 do_patch "patches/proton" qpid-proton-src
 
 cd proton_build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_BINDINGS=python -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_PYTHON=ON -DSSL_IMPL=openssl $WORKING/qpid-proton-src/ \
-    && make \
-    && make DESTDIR=$WORKING/proton_install install \
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_BINDINGS=python -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_PYTHON=ON -DSSL_IMPL=openssl $WORKING/qpid-proton-src/ \
+    && ninja \
+    && DESTDIR=$WORKING/proton_install ninja install \
     && tar -z -C $WORKING/proton_install -cf /qpid-proton-image.tar.gz usr \
-    && make install
+    && ninja install
 cd $WORKING/build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_LIBWEBSOCKETS=ON -DCMAKE_INSTALL_PREFIX=/usr $WORKING/ \
-    && make  \
-    && make DESTDIR=$WORKING/staging/ install \
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_LIBWEBSOCKETS=ON -DCMAKE_INSTALL_PREFIX=/usr $WORKING/ \
+    && ninja  \
+    && DESTDIR=$WORKING/staging/ ninja install \
     && tar -z -C $WORKING/staging/ -cf /skupper-router-image.tar.gz usr etc


### PR DESCRIPTION
There are three ways in which ninja is faster:

1. ninja runs in parallel by default
2. rerunning ninja on unchanged sources more efficiently detects no work needs to be done (not relevant in Dockerfile)
3. the ninja has been explicitly designed to be fast, overall, which make was not

Image works just fine for me.