### PR TITLE
Fixed #197: Wait for routers in test to exit before checking log for raised exceptions

### DIFF
--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -883,7 +883,7 @@ class Tester:
         """Start a Process that will be cleaned up on teardown"""
         return self.cleanup(Process(*args, **kwargs))
 
-    def qdrouterd(self, *args, **kwargs):
+    def qdrouterd(self, *args, **kwargs) -> Qdrouterd:
         """Return a Qdrouterd that will be cleaned up on teardown"""
         return self.cleanup(Qdrouterd(*args, **kwargs))
 


### PR DESCRIPTION
This is the smallest-delta fix that I can think of. I don't like the test on the whole, but I overcame my distaste and urge to rewrite. I am proud of myself.