### PR TITLE
Fixed #221: Add `#include <cstdint>` to cpp_stub.h

### DIFF
--- a/tests/cpp-stub/cpp_stub.h
+++ b/tests/cpp-stub/cpp_stub.h
@@ -21,6 +21,7 @@
 //c
 #include <cstddef>
 #include <cstring>
+#include <cstdint>
 //c++
 #include <map>
 


### PR DESCRIPTION
Upstream issue at https://github.com/coolxv/cpp-stub/issues/24