### PR TITLE
DISPATCH-1344 Relaxing C11 sys_atomic_ operations

### DIFF
--- a/include/qpid/dispatch/atomic.h
+++ b/include/qpid/dispatch/atomic.h
@@ -32,6 +32,8 @@ extern "C++" {
 #include <atomic>
 }
 using std::atomic_uint;
+using std::memory_order_acq_rel;
+using std::memory_order_relaxed;
 #else
 #include <stdatomic.h>
 #endif
@@ -45,22 +47,22 @@ static inline void sys_atomic_init(sys_atomic_t *ref, uint32_t value)
 
 static inline uint32_t sys_atomic_add(sys_atomic_t *ref, uint32_t value)
 {
-    return atomic_fetch_add(ref, value);
+    return atomic_fetch_add_explicit(ref, value, memory_order_relaxed);
 }
 
 static inline uint32_t sys_atomic_sub(sys_atomic_t *ref, uint32_t value)
 {
-    return atomic_fetch_sub(ref, value);
+    return atomic_fetch_sub_explicit(ref, value, memory_order_relaxed);
 }
 
 static inline uint32_t sys_atomic_get(sys_atomic_t *ref)
 {
-    return atomic_load(ref);
+    return atomic_load_explicit(ref, memory_order_relaxed);
 }
 
 static inline uint32_t sys_atomic_set(sys_atomic_t *ref, uint32_t value)
 {
-    return atomic_exchange(ref, value);
+    return atomic_exchange_explicit(ref, value, memory_order_relaxed);
 }
 
 static inline void sys_atomic_destroy(sys_atomic_t *ref) {}
@@ -75,6 +77,6 @@ static inline void sys_atomic_destroy(sys_atomic_t *ref) {}
 static inline uint32_t sys_atomic_inc(sys_atomic_t *ref) { return sys_atomic_add((ref), 1); }
 
 /** Atomic decrease: NOTE returns value *before* decrease, like i-- */
-static inline uint32_t sys_atomic_dec(sys_atomic_t *ref) { return sys_atomic_sub((ref), 1); }
+static inline uint32_t sys_atomic_dec(sys_atomic_t *ref) { return atomic_fetch_sub_explicit(ref, (uint32_t)1, memory_order_acq_rel); }
 
 #endif


### PR DESCRIPTION
This is a revival of DISPATCH-1344. The issue that was never meant to have been abandoned.

@astitcher The shared_ptr article about atomics is actually not an article, but a SO question, https://stackoverflow.com/questions/28199212/why-does-libcs-implementation-of-shared-ptr-use-full-memory-barriers-instead

Regarding the question "What use are the relaxed atomics on x86_64?", as far as I can tell, the hardware recognizes two "levels": `seq_cst` and `everything else`. By that I mean that the generated code for seq_cst store is actually different from non-cst_seq store. But, the relaxation also influences what code will be generated by the compiler. Even if the CPU does not do reorders, the compiler will, and that may be significant for performance, sometimes. (https://stackoverflow.com/questions/61719680/are-memory-orderings-consume-acq-rel-and-seq-cst-ever-needed-on-intel-x86)

So, IMO if this shows promise in benchmark, then there may be value in thinking about this. Ultimately, the atomics, as a way to silence TSan, were not all that great a solution and hopefully they will go away, eventually.