### PR TITLE
Fixed #253: asan leak in qd_policy_c_counts_alloc

### DIFF
--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -5,17 +5,11 @@
 # to be triaged; pretty much all tests
 leak:^IoAdapter_init$
 
-# to be triaged; pretty much all tests
-leak:^load_server_config$
-
 # to be triaged; system_tests_one_router, system_tests_policy
 leak:^qd_policy_open_fetch_settings$
 
 # to be triaged; system_tests_handle_failover
 leak:^parse_failover_property_list$
-
-# to be triaged; system_tests_policy, system_tests_policy_oversize_basic
-leak:^qd_policy_c_counts_alloc$
 
 # to be triaged; system_tests_http
 leak:^callback_healthz$


### PR DESCRIPTION
This one is less trivial that the other recent ones I did.

Since the leaked pointers are only being used in Python -- and never freed -- I keep track of them in the dispatch.c file, and free them all just before the router itself is freed.
