### PR TITLE
[experiment] Compile skupper-router with g++ `-fpermissive`

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# https://clangd.llvm.org/config
+
+CompileFlags:                        # Tweak the parse settings
+  Add: [-xc++, -std=c++20]           # treat all files as C++
+  Compiler: clang++                  # Change argv[0] of compile flags to `clang++`

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -451,6 +451,7 @@ jobs:
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         -DPython_EXECUTABLE=/usr/bin/python3
         -DRUNTIME_CHECK=${{matrix.runtimeCheck}}
+        -DBUILD_AS_CXX=ON
 
       CCACHE_BASEDIR: ${{github.workspace}}
       CCACHE_DIR: ${{github.workspace}}/.ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,22 +100,22 @@ if(NOT DEFINED VERSION)
                       OUTPUT_VARIABLE DEFAULT_VERSION
                       RESULT_VARIABLE GIT_RESULT
                       OUTPUT_STRIP_TRAILING_WHITESPACE)
-                      
-                
+
+
       # You might sometimes get a fatal error when running the above command (when this is not a git repo).
       # GIT_RESULT will contain the result of last child process. It will be zero if successful.
       if (GIT_RESULT EQUAL 0)
           # Git succeeded, we will use the DEFAULT_VERSION as the QPID_DISPATCH_VERSION
           set(QPID_DISPATCH_VERSION ${DEFAULT_VERSION})
        else()
-          # The git command failed, set QPID_DISPATCH_VERSION to "UNKNOWN" 
+          # The git command failed, set QPID_DISPATCH_VERSION to "UNKNOWN"
           set(QPID_DISPATCH_VERSION "UNKNOWN")
        endif(GIT_RESULT EQUAL 0)
    else(Git_FOUND)
        # Git executable was not available, we will not be able to determine the version, just set it to "UNKNOWN"
        set(QPID_DISPATCH_VERSION "UNKNOWN")
    endif(Git_FOUND)
-   
+
 else(NOT DEFINED VERSION)
 
    # What if VERSION is defined but someone passed in an empty value for VERSION? Deal with that case here.
@@ -128,7 +128,7 @@ else(NOT DEFINED VERSION)
       else()
           set(QPID_DISPATCH_VERSION ${VERSION})
       endif()
-   endif(VERSION STREQUAL "")  
+   endif(VERSION STREQUAL "")
 endif(NOT DEFINED VERSION)
 
 message(STATUS "Setting skupper-router version to ${QPID_DISPATCH_VERSION}")
@@ -157,6 +157,12 @@ find_package(LibWebSockets 4.0.1 REQUIRED)
 ##
 ## Optional dependencies
 ##
+
+OPTION(BUILD_AS_CXX "Enable building C code with C++ compiler" OFF)
+if(BUILD_AS_CXX)
+    add_compile_options(-w -Wno-write-strings -Wno-literal-suffix -fpermissive -Wno-error=literal-suffix)
+    add_definitions("-DQD_BUILD_AS_CXX")
+endif()
 
 find_library(dw_lib dw DOC "libdw used to symbolize QD_MEMORY_DEBUG backtraces")
 find_package(libunwind)
@@ -317,3 +323,10 @@ add_subdirectory(docs)
 # That will force automatic re-configure and everybody will be happy.
 #
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/reconfigure.in ${CMAKE_CURRENT_BINARY_DIR}/reconfigure)
+
+if(BUILD_AS_CXX)
+    file(GLOB_RECURSE CFILES "*.c")
+    set_source_files_properties(${CFILES}
+            DIRECTORY src tests router
+            PROPERTIES LANGUAGE CXX)
+endif()

--- a/README.adoc
+++ b/README.adoc
@@ -78,7 +78,7 @@ From the `<build>` directory you can run all the system- and unit-tests with:
 $ ctest -VV
 ----
 
-The `ctest` tool uses the script `<build>/test/run.py` to set up the correct environment for tests. 
+The `ctest` tool uses the script `<build>/test/run.py` to set up the correct environment for tests.
 You can use it to run tests individually from the `<build>/tests` directory.
 
 .Example
@@ -188,8 +188,8 @@ And run the following command to generate grpc code:
 python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. ./friendship.proto
 ----
 
-The system tests are implemented using Python's unittest library. 
-This library is used to run the tests by default. 
+The system tests are implemented using Python's unittest library.
+This library is used to run the tests by default.
 The tests can be also run using `xmlrunner` or `pytest`.
 Pytest can generate a JUnit-compatible XML report containing an entry for each Python test method.
 After running the tests, all XML reports can be found under `tests/junitxmls` in your build directory:
@@ -212,7 +212,7 @@ cmake .. -DQDROUTERD_RUNNER="gdb -quiet -iex 'set pagination off' -iex 'set debu
 
 === Test Suite Code Coverage (GNU tools only)
 
-Use coverage analysis to ensure that all code paths are exercised by the test suite. 
+Use coverage analysis to ensure that all code paths are exercised by the test suite.
 To run the tests and perform code coverage analysis:
 
 . Install the lcov package
@@ -253,11 +253,11 @@ This script then does the following:
 The CTest test suite can be configured to enable extra run time
 validation checks against the skupper router.
 
-Since run time validation slows down `skrouterd` considerably it is disabled by default.  
+Since run time validation slows down `skrouterd` considerably it is disabled by default.
 
 It can be enabled by setting the `RUNTIME_CHECK` build flag via the `cmake` command.
 
-NOTE: Depending on your environment the `ctest` suite may time out if validation is enabled due to the additional run time overhead it adds. 
+NOTE: Depending on your environment the `ctest` suite may time out if validation is enabled due to the additional run time overhead it adds.
 You can extend the default test time via the `ctest --timeout`
 option.
 
@@ -272,7 +272,7 @@ The Skupper Router test suite supports the following run time validation tools:
 ==== Valgrind Memcheck
 
 Memcheck runs `skrouterd` under Valgrind's memcheck leak checker during the CTest suite.
-This causes tests to fail if a memory error is encountered.  
+This causes tests to fail if a memory error is encountered.
 Use the grinder tool (in the bin directory) to create a summary of the errors found during the test run.
 
 The valgrind toolset must be installed in order to use memcheck.
@@ -284,7 +284,7 @@ To enable memcheck set the RUNTIME_CHECK build flag to "memcheck":
 cmake .. -DRUNTIME_CHECK=memcheck
 ----
 
-If valgrind detects errors, the `skrouterd` process exits with an exit code of `42` and a message is displayed in the CTest output. 
+If valgrind detects errors, the `skrouterd` process exits with an exit code of `42` and a message is displayed in the CTest output.
 For example:
 
 [source]
@@ -387,5 +387,8 @@ The `libbenchmark` library is required by the benchmarks.
 
 |`-DENABLE_WARNING_ERROR=OFF`
 |Build will be allowed to succeed when compilation warnings are present.
+
+|`-DBUILD_AS_CXX=ON`
+|C files will be built using CXX compiler.
 
 |===

--- a/include/qpid/dispatch/internal/export.h
+++ b/include/qpid/dispatch/internal/export.h
@@ -19,5 +19,11 @@
 
 /// @cond INTERNAL
 
+#ifdef __cplusplus
+#define QD_EXTERN_C extern "C"
+#else
+#define QD_EXTERN_C
+#endif
+
 /// import/export macros
-#define QD_EXPORT __attribute__((visibility("default"))) __attribute__((used))
+#define QD_EXPORT QD_EXTERN_C __attribute__((visibility("default"))) __attribute__((used))

--- a/router/src/panic.c
+++ b/router/src/panic.c
@@ -135,10 +135,9 @@ void panic_handler_init(void)
 {
     if (getenv("SKUPPER_ROUTER_DISABLE_PANIC_HANDLER") == 0) {
         lib_map_init();
-        struct sigaction sa = {
-            .sa_flags     = SA_SIGINFO | SA_RESETHAND,
-            .sa_sigaction = panic_signal_handler,
-        };
+        struct sigaction sa = {0};
+        sa.sa_flags         = (int) (SA_SIGINFO | SA_RESETHAND);
+        sa.sa_sigaction     = panic_signal_handler;
 
         sigemptyset(&sa.sa_mask);
 

--- a/src/adaptors/adaptor_common.c
+++ b/src/adaptors/adaptor_common.c
@@ -70,9 +70,11 @@ qd_error_t qd_load_adaptor_config(qd_adaptor_config_t *config, qd_entity_t *enti
     if (config->backlog <= 0 || config->backlog > SOMAXCONN)
         config->backlog = SOMAXCONN;
 
-    int hplen = strlen(config->host) + strlen(config->port) + 2;
-    config->host_port = malloc(hplen);
-    snprintf(config->host_port, hplen, "%s:%s", config->host, config->port);
+    {
+        int hplen         = strlen(config->host) + strlen(config->port) + 2;
+        config->host_port = malloc(hplen);
+        snprintf(config->host_port, hplen, "%s:%s", config->host, config->port);
+    }
 
     return QD_ERROR_NONE;
 

--- a/src/adaptors/http_common.c
+++ b/src/adaptors/http_common.c
@@ -93,7 +93,7 @@ static qd_error_t qd_load_http_adaptor_config(qd_http_adaptor_config_t *config, 
     CHECK();
     if (strcmp(version_str, "HTTP2") == 0) {
         config->http_version = HTTP2;
-    } else if (strcmp(version_str, "HTTP1") == 0) {
+    } else if (strcmp(version_str, "HTTP1") == 0){
         config->http_version = HTTP1;
     } else {
         qd_error(QD_ERROR_CONFIG, "Invalid value for HTTP version: %s, expected 'HTTP1' or 'HTTP2'", version_str);

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -314,17 +314,19 @@ static qd_error_t load_server_config(qd_dispatch_t *qd, qd_server_config_t *conf
 {
     qd_error_clear();
 
-    bool authenticatePeer   = qd_entity_opt_bool(entity, "authenticatePeer",  false);    CHECK();
-    bool verifyHostname     = qd_entity_opt_bool(entity, "verifyHostname",    true);     CHECK();
-    bool requireEncryption  = qd_entity_opt_bool(entity, "requireEncryption", false);    CHECK();
-    bool requireSsl         = qd_entity_opt_bool(entity, "requireSsl",        false);    CHECK();
+    {
+        bool authenticatePeer   = qd_entity_opt_bool(entity, "authenticatePeer",  false);    CHECK();
+        bool verifyHostname     = qd_entity_opt_bool(entity, "verifyHostname",    true);     CHECK();
+        bool requireEncryption  = qd_entity_opt_bool(entity, "requireEncryption", false);    CHECK();
+        bool requireSsl         = qd_entity_opt_bool(entity, "requireSsl",        false);    CHECK();
 
-    ZERO(config);
-    config->log_message          = qd_entity_opt_string(entity, "messageLoggingComponents", 0);     CHECK();
-    config->log_bits             = populate_log_message(config);
-    config->port                 = qd_entity_get_string(entity, "port");              CHECK();
-    config->name                 = qd_entity_opt_string(entity, "name", 0);           CHECK();
-    long inter_router_cost       = qd_entity_opt_long(entity, "cost", 1);             CHECK();
+        ZERO(config);
+        config->log_message          = qd_entity_opt_string(entity, "messageLoggingComponents", 0);     CHECK();
+        config->log_bits             = populate_log_message(config);
+        config->port                 = qd_entity_get_string(entity, "port");              CHECK();
+        config->name                 = qd_entity_opt_string(entity, "name", 0);           CHECK();
+
+        long inter_router_cost       = qd_entity_opt_long(entity, "cost", 1);             CHECK();
 
     if (!role_override) {
         config->role = qd_entity_get_string(entity, "role"); CHECK();
@@ -343,31 +345,30 @@ static qd_error_t load_server_config(qd_dispatch_t *qd, qd_server_config_t *conf
     }
 
     config->inter_router_cost = inter_router_cost;
-    config->socket_address_family      = qd_entity_opt_string(entity, "socketAddressFamily", 0); CHECK();
-    config->healthz              = qd_entity_opt_bool(entity, "healthz", true);       CHECK();
-    config->metrics              = qd_entity_opt_bool(entity, "metrics", true);       CHECK();
-    config->websockets           = qd_entity_opt_bool(entity, "websockets", true);    CHECK();
-    config->http                 = qd_entity_opt_bool(entity, "http", false);         CHECK();
-    config->http_root_dir        = qd_entity_opt_string(entity, "httpRootDir", 0);    CHECK();
-    config->http = config->http || config->http_root_dir; /* httpRootDir implies http */
-    config->max_frame_size       = qd_entity_get_long(entity, "maxFrameSize");        CHECK();
-    config->max_sessions         = qd_entity_get_long(entity, "maxSessions");         CHECK();
-    uint64_t ssn_frames          = qd_entity_opt_long(entity, "maxSessionFrames", 0); CHECK();
-    config->idle_timeout_seconds = qd_entity_get_long(entity, "idleTimeoutSeconds");  CHECK();
-    if (is_listener) {
-        config->initial_handshake_timeout_seconds = qd_entity_get_long(entity, "initialHandshakeTimeoutSeconds");  CHECK();
-    }
-    config->sasl_username        = qd_entity_opt_string(entity, "saslUsername", 0);   CHECK();
-    config->sasl_password        = qd_entity_opt_string(entity, "saslPassword", 0);   CHECK();
-    config->sasl_mechanisms      = qd_entity_opt_string(entity, "saslMechanisms", 0); CHECK();
-    config->ssl_profile          = qd_entity_opt_string(entity, "sslProfile", 0);     CHECK();
-    config->link_capacity        = qd_entity_opt_long(entity, "linkCapacity", 0);     CHECK();
-    config->multi_tenant         = qd_entity_opt_bool(entity, "multiTenant", false);  CHECK();
-    config->policy_vhost         = qd_entity_opt_string(entity, "policyVhost", 0);    CHECK();
-    config->conn_props           = qd_entity_opt_map(entity, "openProperties");       CHECK();
+        config->socket_address_family      = qd_entity_opt_string(entity, "socketAddressFamily", 0); CHECK();
+        config->healthz              = qd_entity_opt_bool(entity, "healthz", true);       CHECK();
+        config->metrics              = qd_entity_opt_bool(entity, "metrics", true);       CHECK();
+        config->websockets           = qd_entity_opt_bool(entity, "websockets", true);    CHECK();
+        config->http                 = qd_entity_opt_bool(entity, "http", false);         CHECK();
+        config->http_root_dir        = qd_entity_opt_string(entity, "httpRootDir", 0);    CHECK();
+        config->http = config->http || config->http_root_dir; /* httpRootDir implies http */
+        config->max_frame_size       = qd_entity_get_long(entity, "maxFrameSize");        CHECK();
+        config->max_sessions         = qd_entity_get_long(entity, "maxSessions");         CHECK();
+        uint64_t ssn_frames          = qd_entity_opt_long(entity, "maxSessionFrames", 0); CHECK();
+        config->idle_timeout_seconds = qd_entity_get_long(entity, "idleTimeoutSeconds");  CHECK();
+        if (is_listener) {
+            config->initial_handshake_timeout_seconds = qd_entity_get_long(entity, "initialHandshakeTimeoutSeconds");  CHECK();
+        }
+        config->sasl_username        = qd_entity_opt_string(entity, "saslUsername", 0);   CHECK();
+        config->sasl_password        = qd_entity_opt_string(entity, "saslPassword", 0);   CHECK();
+        config->sasl_mechanisms      = qd_entity_opt_string(entity, "saslMechanisms", 0); CHECK();
+        config->ssl_profile          = qd_entity_opt_string(entity, "sslProfile", 0);     CHECK();
+        config->link_capacity        = qd_entity_opt_long(entity, "linkCapacity", 0);     CHECK();
+        config->multi_tenant         = qd_entity_opt_bool(entity, "multiTenant", false);  CHECK();
+        config->policy_vhost         = qd_entity_opt_string(entity, "policyVhost", 0);    CHECK();
+        config->conn_props           = qd_entity_opt_map(entity, "openProperties");       CHECK();
 
-
-    if (strcmp(config->role, "inter-router") == 0) {
+        if (strcmp(config->role, "inter-router") == 0) {
         // For inter-router connections only, the dataConnectionCount defaults to "auto",
         // which means it will be determined as a function of the number of worker threads.
         config->data_connection_count = strdup(qd->data_connection_count);
@@ -382,110 +383,111 @@ static qd_error_t load_server_config(qd_dispatch_t *qd, qd_server_config_t *conf
 
     set_config_host(config, entity);
 
-    if (config->sasl_password) {
-        //
-        //Process the sasl password field and set the right values based on prefixes.
-        //
-        char *actual_pass = 0;
-        bool is_file_path = 0;
-        qd_config_process_password(&actual_pass, config->sasl_password, &is_file_path, false);
-        if (actual_pass) {
-            if (is_file_path) {
-                   qd_set_password_from_file(actual_pass, &config->sasl_password);
-                   free(actual_pass);
-            }
-            else {
-                free(config->sasl_password);
-                config->sasl_password = actual_pass;
+        if (config->sasl_password) {
+            //
+            //Process the sasl password field and set the right values based on prefixes.
+            //
+            char *actual_pass = 0;
+            bool is_file_path = 0;
+            qd_config_process_password(&actual_pass, config->sasl_password, &is_file_path, false);
+            if (actual_pass) {
+                if (is_file_path) {
+                    qd_set_password_from_file(actual_pass, &config->sasl_password);
+                    free(actual_pass);
+                }
+                else {
+                    free(config->sasl_password);
+                    config->sasl_password = actual_pass;
+                }
             }
         }
-    }
 
-    //
-    // Handle the defaults for various settings
-    //
-    if (config->link_capacity == 0)
-        config->link_capacity = 250;
+        //
+        // Handle the defaults for various settings
+        //
+        if (config->link_capacity == 0)
+            config->link_capacity = 250;
 
-    if (config->max_sessions == 0 || config->max_sessions > 32768)
-        // Proton disallows > 32768
-        config->max_sessions = 32768;
+        if (config->max_sessions == 0 || config->max_sessions > 32768)
+            // Proton disallows > 32768
+            config->max_sessions = 32768;
 
-    if (config->max_frame_size < QD_AMQP_MIN_MAX_FRAME_SIZE)
-        // Silently promote the minimum max-frame-size
-        // Proton will do this but the number is needed for the
-        // incoming capacity calculation.
-        config->max_frame_size = QD_AMQP_MIN_MAX_FRAME_SIZE;
+        if (config->max_frame_size < QD_AMQP_MIN_MAX_FRAME_SIZE)
+            // Silently promote the minimum max-frame-size
+            // Proton will do this but the number is needed for the
+            // incoming capacity calculation.
+            config->max_frame_size = QD_AMQP_MIN_MAX_FRAME_SIZE;
 
-    //
-    // Given session frame count and max frame size, compute session incoming_capacity
-    //   On 64-bit systems the capacity has no practical limit.
-    //   On 32-bit systems the largest default capacity is half the process address space.
-    //
-    bool is_64bit = sizeof(size_t) == 8;
+        //
+        // Given session frame count and max frame size, compute session incoming_capacity
+        //   On 64-bit systems the capacity has no practical limit.
+        //   On 32-bit systems the largest default capacity is half the process address space.
+        //
+        bool is_64bit = sizeof(size_t) == 8;
 #define MAX_32BIT_CAPACITY ((size_t)(2147483647))
-    if (ssn_frames == 0) {
-        config->incoming_capacity = is_64bit ? MAX_32BIT_CAPACITY * (size_t)config->max_frame_size : MAX_32BIT_CAPACITY;
-    } else {
-        // Limited incoming frames.
-        if (is_64bit) {
-            // Specify this to proton by setting capacity to be
-            // the product (max_frame_size * ssn_frames).
-            config->incoming_capacity = (size_t)config->max_frame_size * (size_t)ssn_frames;
+        if (ssn_frames == 0) {
+            config->incoming_capacity = is_64bit ? MAX_32BIT_CAPACITY * (size_t)config->max_frame_size : MAX_32BIT_CAPACITY;
         } else {
-            // 32-bit systems have an upper bound to the capacity
-            uint64_t max_32bit_capacity = (uint64_t)MAX_32BIT_CAPACITY;
-            uint64_t capacity     = (uint64_t)config->max_frame_size * (uint64_t)ssn_frames;
-            if (capacity <= max_32bit_capacity) {
-                config->incoming_capacity = (size_t)capacity;
+            // Limited incoming frames.
+            if (is_64bit) {
+                // Specify this to proton by setting capacity to be
+                // the product (max_frame_size * ssn_frames).
+                config->incoming_capacity = (size_t)config->max_frame_size * (size_t)ssn_frames;
             } else {
-                config->incoming_capacity = MAX_32BIT_CAPACITY;
-                uint64_t actual_frames = max_32bit_capacity / (uint64_t)config->max_frame_size;
+                // 32-bit systems have an upper bound to the capacity
+                uint64_t max_32bit_capacity = (uint64_t)MAX_32BIT_CAPACITY;
+                uint64_t capacity     = (uint64_t)config->max_frame_size * (uint64_t)ssn_frames;
+                if (capacity <= max_32bit_capacity) {
+                    config->incoming_capacity = (size_t)capacity;
+                } else {
+                    config->incoming_capacity = MAX_32BIT_CAPACITY;
+                    uint64_t actual_frames = max_32bit_capacity / (uint64_t)config->max_frame_size;
 
-                qd_log(LOG_CONN_MGR, QD_LOG_WARNING,
-                       "Server configuration for I/O adapter entity name:'%s', host:'%s', port:'%s', "
-                       "requested maxSessionFrames truncated from %" PRId64 " to %" PRId64,
-                       config->name, config->host, config->port, ssn_frames, actual_frames);
+                    qd_log(LOG_CONN_MGR, QD_LOG_WARNING,
+                        "Server configuration for I/O adapter entity name:'%s', host:'%s', port:'%s', "
+                        "requested maxSessionFrames truncated from %"PRId64" to %"PRId64,
+                        config->name, config->host, config->port, ssn_frames, actual_frames);
+                }
             }
         }
-    }
 
-    //
-    // For now we are hardwiring this attribute to true.  If there's an outcry from the
-    // user community, we can revisit this later.
-    //
-    config->allowInsecureAuthentication = true;
-    config->verify_host_name = verifyHostname;
+        //
+        // For now we are hardwiring this attribute to true.  If there's an outcry from the
+        // user community, we can revisit this later.
+        //
+        config->allowInsecureAuthentication = true;
+        config->verify_host_name = verifyHostname;
 
-    char *stripAnnotations  = qd_entity_opt_string(entity, "stripAnnotations", 0);
-    load_strip_annotations(config, stripAnnotations);
-    free(stripAnnotations);
-    stripAnnotations = 0;
-    CHECK();
+        char *stripAnnotations  = qd_entity_opt_string(entity, "stripAnnotations", 0);
+        load_strip_annotations(config, stripAnnotations);
+        free(stripAnnotations);
+        stripAnnotations = 0;
+        CHECK();
 
-    config->requireAuthentication = authenticatePeer;
-    config->requireEncryption     = requireEncryption || requireSsl;
+        config->requireAuthentication = authenticatePeer;
+        config->requireEncryption     = requireEncryption || requireSsl;
 
-    if (config->ssl_profile) {
-        config->ssl_required = requireSsl;
-        config->ssl_require_peer_authentication = config->sasl_mechanisms &&
-            strstr(config->sasl_mechanisms, "EXTERNAL") != 0;
+        if (config->ssl_profile) {
+            config->ssl_required = requireSsl;
+            config->ssl_require_peer_authentication = config->sasl_mechanisms &&
+                strstr(config->sasl_mechanisms, "EXTERNAL") != 0;
 
-        qd_config_ssl_profile_t *ssl_profile =
-            qd_find_ssl_profile(qd->connection_manager, config->ssl_profile);
-        if (ssl_profile) {
-            config->ssl_certificate_file = SSTRDUP(ssl_profile->ssl_certificate_file);
-            config->ssl_private_key_file = SSTRDUP(ssl_profile->ssl_private_key_file);
-            config->ssl_ciphers = SSTRDUP(ssl_profile->ssl_ciphers);
-            config->ssl_protocols = SSTRDUP(ssl_profile->ssl_protocols);
-            config->ssl_password = SSTRDUP(ssl_profile->ssl_password);
-            config->ssl_trusted_certificate_db = SSTRDUP(ssl_profile->ssl_trusted_certificate_db);
-            config->ssl_uid_format = SSTRDUP(ssl_profile->ssl_uid_format);
-            config->ssl_uid_name_mapping_file = SSTRDUP(ssl_profile->uid_name_mapping_file);
+            qd_config_ssl_profile_t *ssl_profile =
+                qd_find_ssl_profile(qd->connection_manager, config->ssl_profile);
+            if (ssl_profile) {
+                config->ssl_certificate_file = SSTRDUP(ssl_profile->ssl_certificate_file);
+                config->ssl_private_key_file = SSTRDUP(ssl_profile->ssl_private_key_file);
+                config->ssl_ciphers = SSTRDUP(ssl_profile->ssl_ciphers);
+                config->ssl_protocols = SSTRDUP(ssl_profile->ssl_protocols);
+                config->ssl_password = SSTRDUP(ssl_profile->ssl_password);
+                config->ssl_trusted_certificate_db = SSTRDUP(ssl_profile->ssl_trusted_certificate_db);
+                config->ssl_uid_format = SSTRDUP(ssl_profile->ssl_uid_format);
+                config->ssl_uid_name_mapping_file = SSTRDUP(ssl_profile->uid_name_mapping_file);
+            }
         }
-    }
 
-    return QD_ERROR_NONE;
+        return QD_ERROR_NONE;
+    }
 
   error:
     qd_server_config_free(config);

--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -192,8 +192,9 @@ static int handle_events(connection_t* c) {
 }
 
 /* The server has a bounded, thread-safe queue for external work */
+enum work_type_t { W_NONE, W_LISTEN, W_CLOSE, W_WAKE, W_STOP, W_HANDLE_STATS };
 typedef struct work_t {
-    enum { W_NONE, W_LISTEN, W_CLOSE, W_WAKE, W_STOP, W_HANDLE_STATS } type;
+    enum work_type_t type;
     void *value;
 } work_t;
 

--- a/src/log.c
+++ b/src/log.c
@@ -82,6 +82,13 @@ typedef enum { DEFAULT, NONE, TRACE, DEBUG, INFO, NOTICE, WARNING, ERROR, CRITIC
 #define MAX_VALID_LEVEL_INDEX CRITICAL
 #define N_LEVEL_INDICES       (MAX_VALID_LEVEL_INDEX - MIN_VALID_LEVEL_INDEX + 1)
 #define LEVEL_INDEX(LEVEL)    ((LEVEL) -TRACE)
+#ifdef __cplusplus
+inline level_index_t &operator++(level_index_t &state)
+{
+    state = static_cast<level_index_t>(static_cast<int>(state) + 1);
+    return state;
+}
+#endif
 
 static const char *SINK_STDOUT = "stdout";
 static const char *SINK_STDERR = "stderr";

--- a/src/log.c
+++ b/src/log.c
@@ -503,29 +503,31 @@ QD_EXPORT PyObject *qd_log_recent_py(long limit) {
     if (PyErr_Occurred()) return NULL;
     PyObject *list = PyList_New(0);
     PyObject *py_entry = NULL;
-    if (!list) goto error;
-    qd_log_entry_t *entry = DEQ_TAIL(entries);
-    while (entry && limit) {
-        const int ENTRY_SIZE=6;
-        py_entry = PyList_New(ENTRY_SIZE);
-        if (!py_entry) goto error;
-        int i = 0;
-        // NOTE: PyList_SetItem steals a reference so no leak here.
-        PyList_SetItem(py_entry, i++, PyUnicode_FromString(entry->module));
-        const char* level = level_name( level_index_for_bit(entry->level) + 2 );
-        PyList_SetItem(py_entry, i++, level ? PyUnicode_FromString(level) : inc_none());
-        PyList_SetItem(py_entry, i++, PyUnicode_FromString(entry->text));
-        PyList_SetItem(py_entry, i++, entry->file ? PyUnicode_FromString(entry->file) : inc_none());
-        PyList_SetItem(py_entry, i++, entry->file ? PyLong_FromLong(entry->line) : inc_none());
-        PyList_SetItem(py_entry, i++, PyLong_FromLongLong((PY_LONG_LONG)entry->time.tv_sec));
-        assert(i == ENTRY_SIZE);
-        if (PyErr_Occurred()) goto error;
-        PyList_Insert(list, 0, py_entry);
-        Py_DECREF(py_entry);
-        if (limit > 0) --limit;
-        entry = DEQ_PREV(entry);
+    {
+        if (!list) goto error;
+        qd_log_entry_t *entry = DEQ_TAIL(entries);
+        while (entry && limit) {
+            const int ENTRY_SIZE=6;
+            py_entry = PyList_New(ENTRY_SIZE);
+            if (!py_entry) goto error;
+            int i = 0;
+            // NOTE: PyList_SetItem steals a reference so no leak here.
+            PyList_SetItem(py_entry, i++, PyUnicode_FromString(entry->module));
+            const char* level = level_name( level_index_for_bit(entry->level) + 2 );
+            PyList_SetItem(py_entry, i++, level ? PyUnicode_FromString(level) : inc_none());
+            PyList_SetItem(py_entry, i++, PyUnicode_FromString(entry->text));
+            PyList_SetItem(py_entry, i++, entry->file ? PyUnicode_FromString(entry->file) : inc_none());
+            PyList_SetItem(py_entry, i++, entry->file ? PyLong_FromLong(entry->line) : inc_none());
+            PyList_SetItem(py_entry, i++, PyLong_FromLongLong((PY_LONG_LONG)entry->time.tv_sec));
+            assert(i == ENTRY_SIZE);
+            if (PyErr_Occurred()) goto error;
+            PyList_Insert(list, 0, py_entry);
+            Py_DECREF(py_entry);
+            if (limit > 0) --limit;
+            entry = DEQ_PREV(entry);
+        }
+        return list;
     }
-    return list;
  error:
     Py_XDECREF(list);
     Py_XDECREF(py_entry);

--- a/src/router_core/agent_config_address.c
+++ b/src/router_core/agent_config_address.c
@@ -584,34 +584,36 @@ char *qdra_config_address_validate_pattern_CT(qd_parsed_field_t *pattern_field,
     }
 
     buf = (char *)qd_iterator_copy(p_iter);
-    char *begin = buf;
-    // strip leading token separators
-    // note: see parse_tree.c for acceptable separator characters
-    while (*begin && strchr("./", *begin))
-        begin++;
+    {
+        char *begin = buf;
+        // strip leading token separators
+        // note: see parse_tree.c for acceptable separator characters
+        while (*begin && strchr("./", *begin))
+            begin++;
 
-    // strip trailing separators
-    while (*begin) {
-        char *end = &begin[strlen(begin) - 1];
-        if (!strchr("./", *end))
-            break;
-        *end = 0;
-    }
+        // strip trailing separators
+        while (*begin) {
+            char *end = &begin[strlen(begin) - 1];
+            if (!strchr("./", *end))
+                break;
+            *end = 0;
+        }
 
-    if (*begin == 0) {
-        *error = ((is_prefix)
-                  ? "Prefix invalid - no tokens"
-                  : "Pattern invalid - no tokens");
-        goto exit;
-    }
+        if (*begin == 0) {
+            *error = ((is_prefix)
+                      ? "Prefix invalid - no tokens"
+                      : "Pattern invalid - no tokens");
+            goto exit;
+        }
 
-    if (is_prefix) {
-        // convert a prefix match into a valid pattern by appending "/#"
-        pattern = malloc(strlen(begin) + 3);
-        strcpy(pattern, begin);
-        strcat(pattern, "/#");
-    } else {
-        pattern = strdup(begin);
+        if (is_prefix) {
+            // convert a prefix match into a valid pattern by appending "/#"
+            pattern = malloc(strlen(begin) + 3);
+            strcpy(pattern, begin);
+            strcat(pattern, "/#");
+        } else {
+            pattern = strdup(begin);
+        }
     }
 
 exit:

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -1396,7 +1396,7 @@ void qdr_check_addr_CT(qdr_core_t *core, qdr_address_t *addr)
 
 /**
  * Process local and remote attributes for this address to see if action is needed.
- * 
+ *
  * This function should be called whenever the local_sole_destination_mesh flag changes state
  * or a remote sole_destination_mesh value is changed.
  */
@@ -2191,7 +2191,7 @@ static void qdr_link_inbound_second_attach_CT(qdr_core_t *core, qdr_action_t *ac
         //
         switch (link->link_type) {
         case QD_LINK_ENDPOINT:
-        case QD_LINK_INTER_EDGE:
+        case QD_LINK_INTER_EDGE: {
             if (link->auto_link) {
                 //
                 // This second-attach is the completion of an auto-link.  If the attach
@@ -2210,7 +2210,7 @@ static void qdr_link_inbound_second_attach_CT(qdr_core_t *core, qdr_action_t *ac
             if (!addr || (DEQ_SIZE(addr->subscriptions) || DEQ_SIZE(addr->rlinks) || qd_bitmask_cardinality(addr->rnodes)))
                 qdr_link_issue_credit_CT(core, link, link->capacity, false);
             break;
-
+        }
         case QD_LINK_ROUTER:
             qdr_attach_link_data_CT(core, conn, link);
             // fallthrough

--- a/src/router_core/modules/heartbeat_edge/heartbeat_edge.c
+++ b/src/router_core/modules/heartbeat_edge/heartbeat_edge.c
@@ -155,7 +155,7 @@ static void on_conn_event(void             *context,
     qcm_heartbeat_edge_t *client = (qcm_heartbeat_edge_t*) context;
 
     switch (event_type) {
-    case QDRC_EVENT_CONN_EDGE_ESTABLISHED:
+    case QDRC_EVENT_CONN_EDGE_ESTABLISHED: {
         client->edge_conn   = conn;
         client->link_credit = 0;
 
@@ -167,6 +167,7 @@ static void on_conn_event(void             *context,
         client->endpoint = qdrc_endpoint_create_link_CT(client->core, client->edge_conn, QD_OUTGOING,
                                                         0, target, &descriptor, client);
         break;
+    }
 
     case QDRC_EVENT_CONN_EDGE_LOST:
         client->edge_conn   = 0;

--- a/src/router_core/modules/stuck_delivery_detection/delivery_tracker.c
+++ b/src/router_core/modules/stuck_delivery_detection/delivery_tracker.c
@@ -35,14 +35,13 @@ static int stuck_age      = PROD_STUCK_AGE;
 
 static void action_handler_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
 
-typedef struct tracker_t tracker_t;
+typedef struct dtracker_t dtracker_t;
 
-struct tracker_t {
+struct dtracker_t {
     qdr_core_t       *core;
     qdr_core_timer_t *timer;
     qdr_link_t_sp     next_link;
 };
-
 
 static void check_delivery_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery_t *dlv)
 {
@@ -97,7 +96,7 @@ static void process_link_CT(qdr_core_t *core, qdr_link_t *link)
 
 static void timer_handler_CT(qdr_core_t *core, void *context)
 {
-    tracker_t  *tracker    = (tracker_t*) context;
+    dtracker_t *tracker    = (dtracker_t *) context;
     qdr_link_t *first_link = DEQ_HEAD(core->open_links);
 
     qd_log(LOG_ROUTER_CORE, QD_LOG_DEBUG, "Stuck Delivery Detection: Starting detection cycle");
@@ -117,7 +116,7 @@ static void action_handler_CT(qdr_core_t *core, qdr_action_t *action, bool disca
     if (discard)
         return;
 
-    tracker_t  *tracker = (tracker_t*) action->args.general.context_1;
+    dtracker_t *tracker = (dtracker_t *) action->args.general.context_1;
     qdr_link_t *link    = safe_deref_qdr_link_t(tracker->next_link);
 
     if (!!link) {
@@ -163,7 +162,7 @@ static bool qdrc_delivery_tracker_enable_CT(qdr_core_t *core)
 
 static void qdrc_delivery_tracker_init_CT(qdr_core_t *core, void **module_context)
 {
-    tracker_t *tracker = NEW(tracker_t);
+    dtracker_t *tracker = NEW(dtracker_t);
     ZERO(tracker);
     tracker->core  = core;
     tracker->timer = qdr_core_timer_CT(core, timer_handler_CT, tracker);
@@ -178,7 +177,7 @@ static void qdrc_delivery_tracker_init_CT(qdr_core_t *core, void **module_contex
 
 static void qdrc_delivery_tracker_final_CT(void *module_context)
 {
-    tracker_t *tracker = (tracker_t*) module_context;
+    dtracker_t *tracker = (dtracker_t *) module_context;
     qdr_core_timer_free_CT(tracker->core, tracker->timer);
     free(tracker);
 }

--- a/src/router_core/modules/test_hooks/core_test_hooks.c
+++ b/src/router_core/modules/test_hooks/core_test_hooks.c
@@ -595,7 +595,7 @@ static void _on_conn_event(void *context, qdrc_event_t type, qdr_connection_t *c
     qd_log(LOG_ROUTER_CORE, QD_LOG_TRACE, "client test on conn event");
 
     switch (type) {
-    case QDRC_EVENT_CONN_OPENED:
+    case QDRC_EVENT_CONN_OPENED: {
         qd_log(LOG_ROUTER_CORE, QD_LOG_TRACE, "client test conn open");
         if (tc->conn)  // already have a conn, ignore
             return;
@@ -617,6 +617,7 @@ static void _on_conn_event(void *context, qdrc_event_t type, qdr_connection_t *c
             assert(tc->core_client);
         }
         break;
+    }
     case QDRC_EVENT_CONN_CLOSED:
         qd_log(LOG_ROUTER_CORE, QD_LOG_TRACE, "client test conn closed");
         if (tc->conn == conn) {

--- a/src/router_core/terminus.c
+++ b/src/router_core/terminus.c
@@ -355,14 +355,14 @@ void qdr_terminus_set_dnp_address_iterator(qdr_terminus_t *term, qd_iterator_t *
         len = strlen(text);
     }
 
-    pn_data_t *new = pn_data(pn_data_size(old));
-    pn_data_put_map(new);
-    pn_data_enter(new);
-    pn_data_put_symbol(new, pn_bytes(strlen(QD_DYNAMIC_NODE_PROPERTY_ADDRESS), QD_DYNAMIC_NODE_PROPERTY_ADDRESS));
-    pn_data_put_string(new, pn_bytes(len, text));
-    pn_data_exit(new);
+    pn_data_t *new_ = pn_data(pn_data_size(old));
+    pn_data_put_map(new_);
+    pn_data_enter(new_);
+    pn_data_put_symbol(new_, pn_bytes(strlen(QD_DYNAMIC_NODE_PROPERTY_ADDRESS), QD_DYNAMIC_NODE_PROPERTY_ADDRESS));
+    pn_data_put_string(new_, pn_bytes(len, text));
+    pn_data_exit(new_);
 
-    term->properties = new;
+    term->properties = new_;
     pn_data_free(old);
 
     if (on_heap)

--- a/src/vanflow.c
+++ b/src/vanflow.c
@@ -544,7 +544,7 @@ static void _vflow_create_router_record(void)
 {
     vflow_record_t *router = vflow_start_record(VFLOW_RECORD_ROUTER, 0);
 
-    const char *namespace  = getenv("POD_NAMESPACE");
+    const char *namespace_  = getenv("POD_NAMESPACE");
     const char *image_name = getenv("APPLICATION_NAME");
     const char *version    = getenv("VERSION");
 
@@ -563,8 +563,8 @@ static void _vflow_create_router_record(void)
         vflow_set_string(router, VFLOW_ATTRIBUTE_HOST_NAME, state->hostname);
     }
 
-    if (!!namespace) {
-        vflow_set_string(router, VFLOW_ATTRIBUTE_NAMESPACE, namespace);
+    if (!!namespace_) {
+        vflow_set_string(router, VFLOW_ATTRIBUTE_NAMESPACE, namespace_);
     }
 
     if (!!image_name) {

--- a/tests/buffer_test.c
+++ b/tests/buffer_test.c
@@ -128,7 +128,7 @@ static char *test_buffer_list_append(void *context)
 
 static char *test_buffer_field(void *context)
 {
-    char *result = 0;
+    char *result                   = 0;
     static const uint8_t data1[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     static const uint8_t data2[10] = {0xF9, 0xF8, 0xF7, 0xF6, 0xF5, 0xF4, 0xF3, 0xF2, 0xF1, 0xF0};
     qd_buffer_list_t list;
@@ -152,14 +152,14 @@ static char *test_buffer_field(void *context)
 
     // verify octet read
 
-    bfield.buffer = DEQ_HEAD(list);
-    bfield.cursor = qd_buffer_base(bfield.buffer);
+    bfield.buffer    = DEQ_HEAD(list);
+    bfield.cursor    = qd_buffer_base(bfield.buffer);
     bfield.remaining = 2000;
 
-    int total_octets = 0;
+    int total_octets       = 0;
     size_t expected_length = 2000;
-    uint8_t next_octet = 0;
-    uint8_t octet = 0xFF;
+    uint8_t next_octet     = 0;
+    uint8_t octet          = 0xFF;
     while (qd_buffer_field_octet(&bfield, &octet)) {
         total_octets += 1;
         expected_length -= 1;
@@ -189,176 +189,185 @@ static char *test_buffer_field(void *context)
 
     // verify advance
 
-    bfield.buffer = DEQ_HEAD(list);
-    bfield.cursor = qd_buffer_base(bfield.buffer);
-    bfield.remaining = 2000;
+    {
+        bfield.buffer    = DEQ_HEAD(list);
+        bfield.cursor    = qd_buffer_base(bfield.buffer);
+        bfield.remaining = 2000;
 
-    size_t amount = qd_buffer_field_advance(&bfield, 2);
-    if (amount != 2) {
-        result = "advance 2 failed";
-        goto exit;
-    }
+        size_t amount = qd_buffer_field_advance(&bfield, 2);
+        if (amount != 2) {
+            result = "advance 2 failed";
+            goto exit;
+        }
 
-    if (!qd_buffer_field_octet(&bfield, &octet) || octet != 2) {
-        result = "expected to advance to '2'";
-        goto exit;
-    }
+        if (!qd_buffer_field_octet(&bfield, &octet) || octet != 2) {
+            result = "expected to advance to '2'";
+            goto exit;
+        }
 
-    amount = qd_buffer_field_advance(&bfield, 1995);
-    if (amount != 1995) {
-        result = "advance 1995 failed";
-        goto exit;
-    }
+        amount = qd_buffer_field_advance(&bfield, 1995);
+        if (amount != 1995) {
+            result = "advance 1995 failed";
+            goto exit;
+        }
 
-    if (bfield.remaining != 2) {
-        result = "expected 2 last octets";
-        goto exit;
-    }
+        if (bfield.remaining != 2) {
+            result = "expected 2 last octets";
+            goto exit;
+        }
 
-    if (!qd_buffer_field_octet(&bfield, &octet) || octet != 0xF1) {
-        result = "expected to advance to '0xF1'";
-        goto exit;
-    }
+        if (!qd_buffer_field_octet(&bfield, &octet) || octet != 0xF1) {
+            result = "expected to advance to '0xF1'";
+            goto exit;
+        }
 
-    amount = qd_buffer_field_advance(&bfield, 3);
-    if (amount != 1 || bfield.remaining != 0) {
-        result = "failed to advance to end of field";
-        goto exit;
-    }
+        amount = qd_buffer_field_advance(&bfield, 3);
+        if (amount != 1 || bfield.remaining != 0) {
+            result = "failed to advance to end of field";
+            goto exit;
+        }
 
-    // verify ncopy
+        // verify ncopy
 
-    bfield.buffer = DEQ_HEAD(list);
-    bfield.cursor = qd_buffer_base(bfield.buffer);
-    bfield.remaining = 2000;
+        bfield.buffer    = DEQ_HEAD(list);
+        bfield.cursor    = qd_buffer_base(bfield.buffer);
+        bfield.remaining = 2000;
 
-    uint8_t dest[10];
-    amount = qd_buffer_field_ncopy(&bfield, dest, 5);
-    if (amount != 5) {
-        result = "failed to ncopy 5";
-        goto exit;
-    }
-    if (memcmp(dest, data1, 5)) {
-        result = "ncopy 5 failed";
-        goto exit;
-    }
-    amount = qd_buffer_field_ncopy(&bfield, dest, 10);
-    if (amount != 10) {
-        result = "failed to ncopy 10";
-        goto exit;
-    }
-    if (memcmp(dest, &data1[5], 5) || memcmp(&dest[5], &data2[0], 5)) {
-        result = "ncopy 10 failed";
-        goto exit;
-    }
-    amount = qd_buffer_field_advance(&bfield, 1980);
-    if (amount != 1980) {
-        result = "advance 1980 failed";
-        goto exit;
-    }
-    amount = qd_buffer_field_ncopy(&bfield, dest, 10);
-    if (amount != 5) {
-        result = "ncopy expected 5 failed";
-        goto exit;
-    }
-    if (memcmp(dest, &data2[5], 5) || bfield.remaining != 0) {
-        result = "ncopy at end failed";
-        goto exit;
+        uint8_t dest[10];
+        amount = qd_buffer_field_ncopy(&bfield, dest, 5);
+        if (amount != 5) {
+            result = "failed to ncopy 5";
+            goto exit;
+        }
+        if (memcmp(dest, data1, 5)) {
+            result = "ncopy 5 failed";
+            goto exit;
+        }
+        amount = qd_buffer_field_ncopy(&bfield, dest, 10);
+        if (amount != 10) {
+            result = "failed to ncopy 10";
+            goto exit;
+        }
+        if (memcmp(dest, &data1[5], 5) || memcmp(&dest[5], &data2[0], 5)) {
+            result = "ncopy 10 failed";
+            goto exit;
+        }
+        amount = qd_buffer_field_advance(&bfield, 1980);
+        if (amount != 1980) {
+            result = "advance 1980 failed";
+            goto exit;
+        }
+        amount = qd_buffer_field_ncopy(&bfield, dest, 10);
+        if (amount != 5) {
+            result = "ncopy expected 5 failed";
+            goto exit;
+        }
+        if (memcmp(dest, &data2[5], 5) || bfield.remaining != 0) {
+            result = "ncopy at end failed";
+            goto exit;
+        }
     }
 
     // verify equal
 
-    bfield.buffer = DEQ_HEAD(list);
-    bfield.cursor = qd_buffer_base(bfield.buffer);
+    bfield.buffer    = DEQ_HEAD(list);
+    bfield.cursor    = qd_buffer_base(bfield.buffer);
     bfield.remaining = 2000;
 
-    const uint8_t pattern[] = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\xF9\xF8\xF7\xF6\xF5\xF4\xF3\xF2\xF1\xF0";
-    const uint8_t pattern_bad[] = "\xF9\xF8\xF7\xF6\xF5\xF4\xF3\xF2\xF1\xF0\xAA";
-    if (qd_buffer_field_equal(&bfield, (uint8_t*) "\x00\x01\x03", 3)) {
-        result = "expected equal 3 to fail";
-        goto exit;
-    }
-    if (bfield.remaining != 2000) {
-        result = "do not advance on failed equal";
-        goto exit;
-    }
-    if (!qd_buffer_field_equal(&bfield, pattern, 20)) {
-        result = "expected pattern match";
-        goto exit;
-    }
-    if (bfield.remaining != 1980) {
-        result = "match did not advance";
-        goto exit;
-    }
-    (void)qd_buffer_field_advance(&bfield, 1960);
-    if (!qd_buffer_field_equal(&bfield, pattern, 10)) {
-        result = "expected sub pattern match";
-        goto exit;
-    }
-    if (qd_buffer_field_equal(&bfield, pattern_bad, 11)) {
-        result = "did not expect sub pattern match";
-        goto exit;
-    }
-    if (bfield.remaining != 10) {
-        result = "mismatch advanced";
-        goto exit;
-    }
-    if (!qd_buffer_field_equal(&bfield, &pattern[10], 9 )) {
-        result = "expected end sub pattern match";
-        goto exit;
-    }
+    {
+        const uint8_t pattern[] = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\xF9\xF8\xF7\xF6\xF5\xF4\xF3\xF2\xF1\xF0";
+        const uint8_t pattern_bad[] = "\xF9\xF8\xF7\xF6\xF5\xF4\xF3\xF2\xF1\xF0\xAA";
+        if (qd_buffer_field_equal(&bfield, (uint8_t *) "\x00\x01\x03", 3)) {
+            result = "expected equal 3 to fail";
+            goto exit;
+        }
+        if (bfield.remaining != 2000) {
+            result = "do not advance on failed equal";
+            goto exit;
+        }
+        if (!qd_buffer_field_equal(&bfield, pattern, 20)) {
+            result = "expected pattern match";
+            goto exit;
+        }
+        if (bfield.remaining != 1980) {
+            result = "match did not advance";
+            goto exit;
+        }
+        (void) qd_buffer_field_advance(&bfield, 1960);
+        if (!qd_buffer_field_equal(&bfield, pattern, 10)) {
+            result = "expected sub pattern match";
+            goto exit;
+        }
+        if (qd_buffer_field_equal(&bfield, pattern_bad, 11)) {
+            result = "did not expect sub pattern match";
+            goto exit;
+        }
+        if (bfield.remaining != 10) {
+            result = "mismatch advanced";
+            goto exit;
+        }
+        if (!qd_buffer_field_equal(&bfield, &pattern[10], 9)) {
+            result = "expected end sub pattern match";
+            goto exit;
+        }
 
-    if (!qd_buffer_field_octet(&bfield, &octet) || octet != 0xF0) {
-        result = "failed to octet read the extra trailing octet in the pattern";
+        if (!qd_buffer_field_octet(&bfield, &octet) || octet != 0xF0) {
+            result = "failed to octet read the extra trailing octet in the pattern";
+        }
     }
 
     // verify buffer list append
 
-    bfield.buffer = DEQ_HEAD(list);
-    bfield.cursor = qd_buffer_base(bfield.buffer);
+    bfield.buffer    = DEQ_HEAD(list);
+    bfield.cursor    = qd_buffer_base(bfield.buffer);
     bfield.remaining = 2000;
 
-    qd_buffer_field_t saved_bfield = bfield;
-    qd_buffer_t *bptr = 0;
+    {
+        qd_buffer_field_t saved_bfield = bfield;
+        qd_buffer_t *bptr              = 0;
 
-    qd_buffer_list_append_field(&other_list, &bfield);
-    if (bfield.remaining) {
-        result = "expected to append 2000 octets";
-        goto exit;
-    }
-    bptr = DEQ_HEAD(other_list);
-    uint32_t cmp_count = 0;
-    while (bptr) {
-        if (!qd_buffer_field_equal(&saved_bfield, qd_buffer_base(bptr), qd_buffer_size(bptr))) {
-            result = "expected list and buffers to be equal";
+        qd_buffer_list_append_field(&other_list, &bfield);
+        if (bfield.remaining) {
+            result = "expected to append 2000 octets";
             goto exit;
         }
-        cmp_count += qd_buffer_size(bptr);
-        bptr = DEQ_NEXT(bptr);
-    }
 
-    if (saved_bfield.remaining != 0) {
-        result = "expected saved_bfield to be empty";
-        goto exit;
-    }
+        bptr               = DEQ_HEAD(other_list);
+        uint32_t cmp_count = 0;
+        while (bptr) {
+            if (!qd_buffer_field_equal(&saved_bfield, qd_buffer_base(bptr), qd_buffer_size(bptr))) {
+                result = "expected list and buffers to be equal";
+                goto exit;
+            }
+            cmp_count += qd_buffer_size(bptr);
+            bptr = DEQ_NEXT(bptr);
+        }
 
-    if (cmp_count != 2000) {
-        result = "did not compare 2000 octets";
-        goto exit;
+        if (saved_bfield.remaining != 0) {
+            result = "expected saved_bfield to be empty";
+            goto exit;
+        }
+
+        if (cmp_count != 2000) {
+            result = "did not compare 2000 octets";
+            goto exit;
+        }
     }
 
     qd_buffer_list_free_buffers(&other_list);
 
-    const char *append_str = "abcdefghijklmnopqrstuvwxyz";
-    qd_buffer_list_append(&other_list, (const uint8_t *)append_str, strlen(append_str));
+    {
+        const char *append_str = "abcdefghijklmnopqrstuvwxyz";
+        qd_buffer_list_append(&other_list, (const uint8_t *) append_str, strlen(append_str));
 
-    bfield.buffer = DEQ_HEAD(other_list);
-    bfield.cursor = qd_buffer_base(bfield.buffer);
-    bfield.remaining = strlen(append_str);
+        bfield.buffer    = DEQ_HEAD(other_list);
+        bfield.cursor    = qd_buffer_base(bfield.buffer);
+        bfield.remaining = strlen(append_str);
 
-    if (!qd_buffer_field_equal(&bfield, (const uint8_t*) append_str, strlen(append_str))) {
-        result = "expected to equal append_str";
-        goto exit;
+        if (!qd_buffer_field_equal(&bfield, (const uint8_t *) append_str, strlen(append_str))) {
+            result = "expected to equal append_str";
+            goto exit;
+        }
     }
 
 exit:

--- a/tests/c_benchmarks/bm_tcp_adapter.cpp
+++ b/tests/c_benchmarks/bm_tcp_adapter.cpp
@@ -33,7 +33,7 @@
 #include <csignal>
 #include <iostream>
 
-extern "C" {
+QD_TEST_EXTERN_C {
 #include "entity_cache.h"
 #include "log_private.h"
 #include "parse_tree.h"

--- a/tests/c_unittests/CMakeLists.txt
+++ b/tests/c_unittests/CMakeLists.txt
@@ -28,6 +28,12 @@ if(NOT dw_lib)
     add_compile_definitions("QD_SKIP_LIBDW_TESTS")
 endif()
 
+if(BUILD_AS_CXX)
+    file(GLOB_RECURSE CFILES "*.c")
+    set_source_files_properties(${CFILES}
+            PROPERTIES LANGUAGE CXX)
+endif()
+
 add_library(static_accessors_server_c SHARED
         static_accessors_server_c.c)
 target_compile_options(static_accessors_server_c PRIVATE -fvisibility=hidden)

--- a/tests/c_unittests/helpers.hpp
+++ b/tests/c_unittests/helpers.hpp
@@ -32,6 +32,12 @@
 #include <sstream>
 #include <type_traits>
 
+#ifdef QD_BUILD_AS_CXX
+    #define QD_TEST_EXTERN_C extern "C++"
+#else
+    #define QD_TEST_EXTERN_C extern "C"
+#endif
+
 // assertions without stack traces when running outside doctest
 #ifndef QDR_DOCTEST
 // https://stackoverflow.com/questions/3767869/adding-message-to-assert
@@ -61,7 +67,7 @@ std::cerr << "Assertion `" #condition "` failed in " << __FILE__ \
 } while (false)
 #endif  // QDR_DOCTEST
 
-extern "C" {
+QD_TEST_EXTERN_C {
 #include <dispatch_private.h>
 #include <qpid/dispatch/dispatch.h>
 #include <router_core/router_core_private.h>
@@ -71,7 +77,7 @@ QD_EXPORT void qd_router_setup_late(qd_dispatch_t *qd);
 }
 
 // low-level router initialization
-extern "C" {
+QD_TEST_EXTERN_C {
 #include "entity_cache.h"
 #include "log_private.h"
 

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -18,8 +18,9 @@
  */
 
 #include "qdr_doctest.hpp"
+#include "helpers.hpp"
 
-extern "C" {
+QD_TEST_EXTERN_C {
 #include "qpid/dispatch/internal/symbolization.h"
 }
 

--- a/tests/c_unittests/test_amqp.cpp
+++ b/tests/c_unittests/test_amqp.cpp
@@ -18,8 +18,9 @@
  */
 
 #include "qdr_doctest.hpp"
+#include "helpers.hpp"
 
-extern "C" {
+QD_TEST_EXTERN_C {
 #include "qpid/dispatch/amqp.h"
 }
 

--- a/tests/c_unittests/test_listener_startup.cpp
+++ b/tests/c_unittests/test_listener_startup.cpp
@@ -25,7 +25,7 @@
 #include <regex>
 #include <thread>
 
-extern "C" {
+QD_TEST_EXTERN_C {
 qd_listener_t *qd_dispatch_configure_listener(qd_dispatch_t *qd, qd_entity_t *entity);
 void qd_connection_manager_delete_listener(qd_dispatch_t *qd, void *impl);
 }

--- a/tests/c_unittests/test_server.cpp
+++ b/tests/c_unittests/test_server.cpp
@@ -27,7 +27,7 @@
 #include <string>
 using std::string_literals::operator""s;
 
-extern "C" {
+QD_TEST_EXTERN_C {
 double testonly_normalize_memory_size(const uint64_t bytes, const char **suffix);
 }
 

--- a/tests/c_unittests/test_terminus.cpp
+++ b/tests/c_unittests/test_terminus.cpp
@@ -18,13 +18,13 @@
  */
 
 #include "qdr_doctest.hpp"
-
+#include "helpers.hpp"
 #include "cpp_stub.h"
 
 #include <string>
 using std::string_literals::operator""s;
 
-extern "C" {
+QD_TEST_EXTERN_C {
 #include "qpid/dispatch/router_core.h"
 
 #include <../src/router_core/router_core_private.h>

--- a/tests/compose_test.c
+++ b/tests/compose_test.c
@@ -445,53 +445,56 @@ static char *test_compose_buffer_field(void *context)
         goto exit;
     }
 
-    qd_parsed_field_t *pvalue = qd_parse_value_by_key(pmap, "key1");
-    if (!pvalue || qd_parse_as_uint(pvalue) != 10) {
-        error = "Failed to parse key1";
-        goto exit;
-    }
+    {
+        qd_parsed_field_t *pvalue = qd_parse_value_by_key(pmap, "key1");
+        if (!pvalue || qd_parse_as_uint(pvalue) != 10) {
+            error = "Failed to parse key1";
+            goto exit;
+        }
 
-    pvalue = qd_parse_value_by_key(pmap, "key3");
-    if (!pvalue || qd_parse_as_uint(pvalue) != 99) {
-        error = "Failed to parse key3";
-        goto exit;
-    }
+        pvalue = qd_parse_value_by_key(pmap, "key3");
+        if (!pvalue || qd_parse_as_uint(pvalue) != 99) {
+            error = "Failed to parse key3";
+            goto exit;
+        }
 
-    qd_parsed_field_t *plist = qd_parse_value_by_key(pmap, "key2");
-    if (!plist || !qd_parse_is_list(plist)) {
-        error = "Failed to parse key2";
-        goto exit;
-    }
+        qd_parsed_field_t *plist = qd_parse_value_by_key(pmap, "key2");
+        if (!plist || !qd_parse_is_list(plist)) {
+            error = "Failed to parse key2";
+            goto exit;
+        }
 
-    if (qd_parse_sub_count(plist) != 3) {
-        error = "Invalid list count";
-        goto exit;
-    }
+        if (qd_parse_sub_count(plist) != 3) {
+            error = "Invalid list count";
+            goto exit;
+        }
 
-    pvalue = qd_parse_sub_value(plist, 0);
-    if (!pvalue || qd_parse_as_ulong(pvalue) != 66) {
-        error = "Invalid element 0";
-        goto exit;
-    }
+        pvalue = qd_parse_sub_value(plist, 0);
+        if (!pvalue || qd_parse_as_ulong(pvalue) != 66) {
+            error = "Invalid element 0";
+            goto exit;
+        }
 
-    pvalue = qd_parse_sub_value(plist, 1);
-    if (!pvalue) {
-        error = "Missing list element 1";
-        goto exit;
-    }
+        pvalue = qd_parse_sub_value(plist, 1);
+        if (!pvalue) {
+            error = "Missing list element 1";
+            goto exit;
+        }
 
-    qd_iterator_t *citer = qd_parse_raw(pvalue);
-    if (!citer || !qd_iterator_equal(citer, (const unsigned char*) "abcde")) {
-        error = "Invalid element 1";
-        goto exit;
-    }
+        {
+            qd_iterator_t *citer = qd_parse_raw(pvalue);
+            if (!citer || !qd_iterator_equal(citer, (const unsigned char *) "abcde")) {
+                error = "Invalid element 1";
+                goto exit;
+            }
+        }
 
-    pvalue = qd_parse_sub_value(plist, 2);
-    if (!pvalue || !qd_parse_is_list(pvalue) || qd_parse_sub_count(pvalue) != 0) {
-        error = "Invalid element 2";
-        goto exit;
+        pvalue = qd_parse_sub_value(plist, 2);
+        if (!pvalue || !qd_parse_is_list(pvalue) || qd_parse_sub_count(pvalue) != 0) {
+            error = "Invalid element 2";
+            goto exit;
+        }
     }
-
 
 exit:
 

--- a/tests/field_test.c
+++ b/tests/field_test.c
@@ -490,24 +490,24 @@ static char* test_view_node_hash(void *context)
 
 static char *field_advance_test(void *context,
                                 qd_iterator_t *iter,
-                                const unsigned char *template,
+                                const unsigned char *template_,
                                 int increment)
 {
-    const unsigned char *original = template;
-    while (*template) {
+    const unsigned char *original = template_;
+    while (*template_) {
         // since qd_iterator_equal() resets the iterator to its original
         // view, we need to snapshot the iterator at the current point:
         qd_iterator_t *raw = qd_iterator_sub(iter, qd_iterator_remaining(iter));
-        if (!qd_iterator_equal(raw, (unsigned char*) template)) {
+        if (!qd_iterator_equal(raw, (unsigned char*) template_)) {
 
             snprintf(fail_text, FAIL_TEXT_SIZE,
                      "Field advance failed.  Expected '%s'",
-                     (char *)template );
+                     (char *)template_ );
             qd_iterator_free(raw);
             return fail_text;
         }
         qd_iterator_advance(iter, increment);
-        template += increment;
+        template_ += increment;
         qd_iterator_free(raw);
     }
     if (!qd_iterator_end(iter))
@@ -531,10 +531,10 @@ static char *field_advance_test(void *context,
 
 static char* test_field_advance_string(void *context)
 {
-    const char *template = "abcdefghijklmnopqrstuvwxyz";
-    qd_iterator_t *iter = qd_iterator_string(template, ITER_VIEW_ALL);
+    const char *template_ = "abcdefghijklmnopqrstuvwxyz";
+    qd_iterator_t *iter = qd_iterator_string(template_, ITER_VIEW_ALL);
     return field_advance_test(context, iter,
-                              (const unsigned char*)template, 2);
+                              (const unsigned char*)template_, 2);
 }
 
 
@@ -542,10 +542,10 @@ static char* test_field_advance_buffer(void *context)
 {
     qd_buffer_list_t chain;
     DEQ_INIT(chain);
-    const unsigned char *template = (unsigned char *)"AAABBB";
-    build_buffer_chain(&chain, (const char *)template, 3);
+    const unsigned char *template_ = (unsigned char *)"AAABBB";
+    build_buffer_chain(&chain, (const char *)template_, 3);
     qd_iterator_t *iter = qd_iterator_buffer(DEQ_HEAD(chain), 0, 6, ITER_VIEW_ALL);
-    char *ret = field_advance_test(context, iter, template, 1);
+    char *ret = field_advance_test(context, iter, template_, 1);
     release_buffer_chain(&chain);
     return ret;
 }

--- a/tests/message_test.c
+++ b/tests/message_test.c
@@ -182,11 +182,11 @@ static char* test_receive_from_messenger(void *context)
 static char* test_message_properties(void *context)
 {
     pn_atom_t id = {.type = PN_STRING,
-                    .u.as_bytes.start = "messageId",
-                    .u.as_bytes.size = 9};
+                    .u = {.as_bytes = {.size = 9,
+                                       .start = "messageId"}}};
     pn_atom_t cid = {.type = PN_STRING,
-                     .u.as_bytes.start = "correlationId",
-                     .u.as_bytes.size = 13};
+                     .u = {.as_bytes = {.size = 13,
+                                        .start = "correlationId"}}};
     const char *subject = "A Subject";
     pn_message_t *pn_msg = pn_message();
     pn_message_set_id(pn_msg, id);

--- a/tests/parse_test.c
+++ b/tests/parse_test.c
@@ -295,10 +295,10 @@ static char *test_integer_conversion(void *context)
 
 static char *test_map(void *context)
 {
-    qd_iterator_t     *val_iter = 0;
-    qd_iterator_t     *typed_iter = 0;
-    qd_iterator_t     *key_iter = 0;
-    static char error[1000] = "";
+    qd_iterator_t *val_iter   = 0;
+    qd_iterator_t *typed_iter = 0;
+    qd_iterator_t *key_iter   = 0;
+    static char error[1000]   = "";
     const uint8_t data[] =
         "\xd1\x00\x00\x00\x43\x00\x00\x00\x08"    // map32, 8 items
         "\xa3\x05\x66irst\xa1\x0evalue_of_first"  // (23) "first":"value_of_first"
@@ -311,8 +311,8 @@ static char *test_map(void *context)
     qd_buffer_list_t buflist = DEQ_EMPTY;
     qd_buffer_list_append(&buflist, data, sizeof(data));
 
-    qd_iterator_t     *data_iter = qd_iterator_buffer(DEQ_HEAD(buflist), 0, sizeof(data), ITER_VIEW_ALL);
-    qd_parsed_field_t *field     = qd_parse(data_iter);
+    qd_iterator_t *data_iter = qd_iterator_buffer(DEQ_HEAD(buflist), 0, sizeof(data), ITER_VIEW_ALL);
+    qd_parsed_field_t *field = qd_parse(data_iter);
     qd_iterator_free(data_iter);
 
     if (!qd_parse_ok(field)) {
@@ -325,133 +325,135 @@ static char *test_map(void *context)
         goto exit;
     }
 
-    uint32_t count = qd_parse_sub_count(field);
-    if (count != 4) {
-        snprintf(error, 1000, "Expected sub-count==4, got %"PRIu32, count);
-        goto exit;
-    }
+    {
+        uint32_t count = qd_parse_sub_count(field);
+        if (count != 4) {
+            snprintf(error, 1000, "Expected sub-count==4, got %" PRIu32, count);
+            goto exit;
+        }
 
-    // Validate "first":"value_of_first"
+        // Validate "first":"value_of_first"
 
-    qd_parsed_field_t *key_field  = qd_parse_sub_key(field, 0);
-    key_iter   = qd_parse_raw(key_field);
-    typed_iter = qd_parse_typed(key_field);
-    if (!qd_iterator_equal(key_iter, (unsigned char*) "first")) {
-        unsigned char     *result   = qd_iterator_copy(key_iter);
-        snprintf(error, 1000, "First key: expected 'first', got '%s'", result);
-        free (result);
-        goto exit;
-    }
+        qd_parsed_field_t *key_field = qd_parse_sub_key(field, 0);
+        key_iter                     = qd_parse_raw(key_field);
+        typed_iter                   = qd_parse_typed(key_field);
+        if (!qd_iterator_equal(key_iter, (unsigned char *) "first")) {
+            unsigned char *result = qd_iterator_copy(key_iter);
+            snprintf(error, 1000, "First key: expected 'first', got '%s'", result);
+            free(result);
+            goto exit;
+        }
 
-    if (!qd_iterator_equal(typed_iter, (unsigned char*) "\xa3\x05\x66irst"))
-        return "Incorrect typed iterator on first-key";
+        if (!qd_iterator_equal(typed_iter, (unsigned char *) "\xa3\x05\x66irst"))
+            return "Incorrect typed iterator on first-key";
 
-    qd_parsed_field_t *val_field = qd_parse_sub_value(field, 0);
-    val_iter  = qd_parse_raw(val_field);
-    typed_iter = qd_parse_typed(val_field);
-    if (!qd_iterator_equal(val_iter, (unsigned char*) "value_of_first")) {
-        unsigned char     *result   = qd_iterator_copy(val_iter);
-        snprintf(error, 1000, "First value: expected 'value_of_first', got '%s'", result);
-        free (result);
-        goto exit;
-    }
+        qd_parsed_field_t *val_field = qd_parse_sub_value(field, 0);
+        val_iter                     = qd_parse_raw(val_field);
+        typed_iter                   = qd_parse_typed(val_field);
+        if (!qd_iterator_equal(val_iter, (unsigned char *) "value_of_first")) {
+            unsigned char *result = qd_iterator_copy(val_iter);
+            snprintf(error, 1000, "First value: expected 'value_of_first', got '%s'", result);
+            free(result);
+            goto exit;
+        }
 
-    if (!qd_iterator_equal(typed_iter, (unsigned char*) "\xa1\x0evalue_of_first"))
-        return "Incorrect typed iterator on first-key";
+        if (!qd_iterator_equal(typed_iter, (unsigned char *) "\xa1\x0evalue_of_first"))
+            return "Incorrect typed iterator on first-key";
 
-    // Validate "second:32"
+        // Validate "second:32"
 
-    key_field = qd_parse_sub_key(field, 1);
-    key_iter  = qd_parse_raw(key_field);
-    if (!qd_iterator_equal(key_iter, (unsigned char*) "second")) {
-        unsigned char     *result   = qd_iterator_copy(key_iter);
-        snprintf(error, 1000, "Second key: expected 'second', got '%s'", result);
-        free (result);
-        goto exit;
-    }
+        key_field = qd_parse_sub_key(field, 1);
+        key_iter  = qd_parse_raw(key_field);
+        if (!qd_iterator_equal(key_iter, (unsigned char *) "second")) {
+            unsigned char *result = qd_iterator_copy(key_iter);
+            snprintf(error, 1000, "Second key: expected 'second', got '%s'", result);
+            free(result);
+            goto exit;
+        }
 
-    val_field = qd_parse_sub_value(field, 1);
-    if (qd_parse_as_uint(val_field) != 32) {
-        snprintf(error, 1000, "Second value: expected 32, got %"PRIu32, qd_parse_as_uint(val_field));
-        goto exit;
-    }
+        val_field = qd_parse_sub_value(field, 1);
+        if (qd_parse_as_uint(val_field) != 32) {
+            snprintf(error, 1000, "Second value: expected 32, got %" PRIu32, qd_parse_as_uint(val_field));
+            goto exit;
+        }
 
-    // Validate "third":true
+        // Validate "third":true
 
-    key_field = qd_parse_sub_key(field, 2);
-    key_iter  = qd_parse_raw(key_field);
-    if (!qd_iterator_equal(key_iter, (unsigned char*) "third")) {
-        unsigned char     *result   = qd_iterator_copy(key_iter);
-        snprintf(error, 1000, "Third key: expected 'third', got '%s'", result);
-        free (result);
-        goto exit;
-    }
+        key_field = qd_parse_sub_key(field, 2);
+        key_iter  = qd_parse_raw(key_field);
+        if (!qd_iterator_equal(key_iter, (unsigned char *) "third")) {
+            unsigned char *result = qd_iterator_copy(key_iter);
+            snprintf(error, 1000, "Third key: expected 'third', got '%s'", result);
+            free(result);
+            goto exit;
+        }
 
-    val_field = qd_parse_sub_value(field, 2);
-    if (!qd_parse_as_bool(val_field)) {
-        snprintf(error, 1000, "Third value: expected true");
-        goto exit;
-    }
+        val_field = qd_parse_sub_value(field, 2);
+        if (!qd_parse_as_bool(val_field)) {
+            snprintf(error, 1000, "Third value: expected true");
+            goto exit;
+        }
 
-    // Validate 32768:"!+!+!+!+"
+        // Validate 32768:"!+!+!+!+"
 
-    uint8_t octet;
-    uint8_t ncopy_buf[8];
+        uint8_t octet;
+        uint8_t ncopy_buf[8];
 
-    key_field = qd_parse_sub_key(field, 3);
-    typed_iter = qd_parse_typed(key_field);
+        key_field  = qd_parse_sub_key(field, 3);
+        typed_iter = qd_parse_typed(key_field);
 
-    octet = qd_iterator_octet(typed_iter);
-    if (octet != (uint8_t)0x80) {
-        snprintf(error, sizeof(error), "4th Key not ulong type");
-        goto exit;
-    }
-    if (qd_iterator_ncopy_octets(typed_iter, ncopy_buf, 8) != 8) {
-        snprintf(error, sizeof(error), "4th Key incorrect length");
-        goto exit;
-    }
-    if (memcmp(ncopy_buf, "\x00\x00\x00\x00\x00\x00\x80\x00", 8) != 0) {
-        snprintf(error, sizeof(error), "4th key encoding value incorrect");
-        goto exit;
-    }
-    if (qd_parse_as_ulong(key_field) != 32768) {
-        snprintf(error, sizeof(error), "4th key value not 32768");
-        goto exit;
-    }
+        octet = qd_iterator_octet(typed_iter);
+        if (octet != (uint8_t) 0x80) {
+            snprintf(error, sizeof(error), "4th Key not ulong type");
+            goto exit;
+        }
+        if (qd_iterator_ncopy_octets(typed_iter, ncopy_buf, 8) != 8) {
+            snprintf(error, sizeof(error), "4th Key incorrect length");
+            goto exit;
+        }
+        if (memcmp(ncopy_buf, "\x00\x00\x00\x00\x00\x00\x80\x00", 8) != 0) {
+            snprintf(error, sizeof(error), "4th key encoding value incorrect");
+            goto exit;
+        }
+        if (qd_parse_as_ulong(key_field) != 32768) {
+            snprintf(error, sizeof(error), "4th key value not 32768");
+            goto exit;
+        }
 
-    val_field = qd_parse_sub_value(field, 3);
-    val_iter = qd_parse_raw(val_field);
-    typed_iter = qd_parse_typed(val_field);
+        val_field  = qd_parse_sub_value(field, 3);
+        val_iter   = qd_parse_raw(val_field);
+        typed_iter = qd_parse_typed(val_field);
 
-    octet = qd_iterator_octet(typed_iter);
-    if (octet != (uint8_t)0xb0) {
-        snprintf(error, sizeof(error), "4th Value not vbin32 type: 0x%X", (unsigned int)octet);
-        goto exit;
-    }
-    if (qd_iterator_ncopy_octets(typed_iter, ncopy_buf, 4) != 4) {
-        snprintf(error, sizeof(error), "4th Value incorrect length");
-        goto exit;
-    }
-    if (memcmp(ncopy_buf, "\x00\x00\x00\x08", 4) != 0) {
-        snprintf(error, sizeof(error), "4th Value encoding incorrect");
-        goto exit;
-    }
+        octet = qd_iterator_octet(typed_iter);
+        if (octet != (uint8_t) 0xb0) {
+            snprintf(error, sizeof(error), "4th Value not vbin32 type: 0x%X", (unsigned int) octet);
+            goto exit;
+        }
+        if (qd_iterator_ncopy_octets(typed_iter, ncopy_buf, 4) != 4) {
+            snprintf(error, sizeof(error), "4th Value incorrect length");
+            goto exit;
+        }
+        if (memcmp(ncopy_buf, "\x00\x00\x00\x08", 4) != 0) {
+            snprintf(error, sizeof(error), "4th Value encoding incorrect");
+            goto exit;
+        }
 
-    if (qd_iterator_octet(val_iter) != '!' || qd_iterator_octet(val_iter) != '+') {
-        snprintf(error, sizeof(error), "4th Value [0-1] incorrect");
-        goto exit;
-    }
-    if (qd_iterator_ncopy_octets(typed_iter, ncopy_buf, 4) != 4) {
-        snprintf(error, sizeof(error), "4th Value sub-copy failed");
-        goto exit;
-    }
-    if (memcmp(ncopy_buf, "!+!+", 4) != 0) {
-        snprintf(error, sizeof(error), "4th Value sub-copy incorrect");
-        goto exit;
-    }
-    if (qd_iterator_octet(val_iter) != '!' || qd_iterator_octet(val_iter) != '+') {
-        snprintf(error, sizeof(error), "4th Value [6-7] incorrect");
-        goto exit;
+        if (qd_iterator_octet(val_iter) != '!' || qd_iterator_octet(val_iter) != '+') {
+            snprintf(error, sizeof(error), "4th Value [0-1] incorrect");
+            goto exit;
+        }
+        if (qd_iterator_ncopy_octets(typed_iter, ncopy_buf, 4) != 4) {
+            snprintf(error, sizeof(error), "4th Value sub-copy failed");
+            goto exit;
+        }
+        if (memcmp(ncopy_buf, "!+!+", 4) != 0) {
+            snprintf(error, sizeof(error), "4th Value sub-copy incorrect");
+            goto exit;
+        }
+        if (qd_iterator_octet(val_iter) != '!' || qd_iterator_octet(val_iter) != '+') {
+            snprintf(error, sizeof(error), "4th Value [6-7] incorrect");
+            goto exit;
+        }
     }
 
 
@@ -576,41 +578,43 @@ static char *test_tracemask(void *context)
         sprintf(error, "(A) Expected ingress index of 0, got %d", ingress);
         goto cleanup;
     }
-    int total = 0;
-    int bit, c;
-    for (QD_BITMASK_EACH(bm, bit, c)) {
-        total += bit;
-    }
-    if (total != 17) {
-        sprintf(error, "Expected total bit value of 17, got %d", total);
-        goto cleanup;
-    }
+    {
+        int total = 0;
+        int bit, c;
+        for (QD_BITMASK_EACH(bm, bit, c)) {
+            total += bit;
+        }
+        if (total != 17) {
+            sprintf(error, "Expected total bit value of 17, got %d", total);
+            goto cleanup;
+        }
 
-    qd_bitmask_free(bm);
-    bm = 0;
-    qd_tracemask_del_router(tm, 3);
-    qd_tracemask_remove_link(tm, 0);
+        qd_bitmask_free(bm);
+        bm = 0;
+        qd_tracemask_del_router(tm, 3);
+        qd_tracemask_remove_link(tm, 0);
 
-    ingress = -1;
-    bm = qd_tracemask_create(tm, pf, &ingress);
-    qd_parse_free(pf);
-    pf = 0;
-    if (qd_bitmask_cardinality(bm) != 1) {
-        sprintf(error, "Expected cardinality of 1, got %d", qd_bitmask_cardinality(bm));
-        goto cleanup;
-    }
-    if (ingress != 0) {
-        sprintf(error, "(B) Expected ingress index of 0, got %d", ingress);
-        goto cleanup;
-    }
+        ingress = -1;
+        bm = qd_tracemask_create(tm, pf, &ingress);
+        qd_parse_free(pf);
+        pf = 0;
+        if (qd_bitmask_cardinality(bm) != 1) {
+            sprintf(error, "Expected cardinality of 1, got %d", qd_bitmask_cardinality(bm));
+            goto cleanup;
+        }
+        if (ingress != 0) {
+            sprintf(error, "(B) Expected ingress index of 0, got %d", ingress);
+            goto cleanup;
+        }
 
-    total = 0;
-    for (QD_BITMASK_EACH(bm, bit, c)) {
-        total += bit;
-    }
-    if (total != 3) {
-        sprintf(error, "Expected total bit value of 3, got %d", total);
-        // fallthrough
+        total = 0;
+        for (QD_BITMASK_EACH(bm, bit, c)) {
+            total += bit;
+        }
+        if (total != 3) {
+            sprintf(error, "Expected total bit value of 3, got %d", total);
+            // fallthrough
+        }
     }
 
 cleanup:
@@ -645,69 +649,69 @@ static char *test_field_api(void *context)
                                              qd_buffer_list_length(&blist),
                                              ITER_VIEW_ALL);
 
-    qd_parsed_field_t *parsed = qd_parse(iter);
-    if (!parsed || qd_parse_sub_count(parsed) != 3) {
-        result = "failed to parse";
-        goto exit;
-    }
+    qd_parsed_field_t *parsed = 0;
+    {
+        parsed = qd_parse(iter);
+        if (!parsed || qd_parse_sub_count(parsed) != 3) {
+            result = "failed to parse";
+            goto exit;
+        }
 
-    qd_buffer_field_t typed = qd_parse_typed_field(parsed);
-    uint8_t octet;
-    if (!qd_buffer_field_octet(&typed, &octet)) {
-        result = "qd_parse_typed_field: no tag";
-        goto exit;
-    }
+        qd_buffer_field_t typed = qd_parse_typed_field(parsed);
+        uint8_t octet;
+        if (!qd_buffer_field_octet(&typed, &octet)) {
+            result = "qd_parse_typed_field: no tag";
+            goto exit;
+        }
 
-    if (octet != qd_parse_tag(parsed)) {
-        result = "qd_parse_typed_field: wrong tag";
-        goto exit;
-    }
+        if (octet != qd_parse_tag(parsed)) {
+            result = "qd_parse_typed_field: wrong tag";
+            goto exit;
+        }
 
-    // check the list content
+        // check the list content
 
-    qd_parsed_field_t *sub = qd_parse_sub_value(parsed, 0);
-    typed = qd_parse_typed_field(sub);
-    qd_buffer_field_t raw = qd_parse_raw_field(sub);
-    if (!qd_buffer_field_octet(&typed, &octet)
-        || octet != qd_parse_tag(sub)) {
-        result = "sub 0: failed typed";
-        goto exit;
-    }
-    if (!qd_buffer_field_equal(&raw, (uint8_t*) "STR8-UTF8", strlen("STR8-UTF8"))) {
-        result = "sub 0: failed raw";
-        goto exit;
-    }
+        qd_parsed_field_t *sub = qd_parse_sub_value(parsed, 0);
+        typed                  = qd_parse_typed_field(sub);
+        qd_buffer_field_t raw  = qd_parse_raw_field(sub);
+        if (!qd_buffer_field_octet(&typed, &octet) || octet != qd_parse_tag(sub)) {
+            result = "sub 0: failed typed";
+            goto exit;
+        }
+        if (!qd_buffer_field_equal(&raw, (uint8_t *) "STR8-UTF8", strlen("STR8-UTF8"))) {
+            result = "sub 0: failed raw";
+            goto exit;
+        }
 
-    sub = qd_parse_sub_value(parsed, 1);
-    typed = qd_parse_typed_field(sub);
-    raw = qd_parse_raw_field(sub);
-    if (!qd_buffer_field_octet(&typed, &octet)
-        || octet != qd_parse_tag(sub)) {
-        result = "sub 1: failed typed";
-        goto exit;
-    }
-    if (octet != QD_AMQP_UINT || raw.remaining != 4) {
-        result = "sub 1: unexpected type";
-        goto exit;
-    }
-    uint32_t uint_read;
-    if (!qd_buffer_field_uint32(&raw, &uint_read) || uint_read != uint_val) {
-        result = "sub 1: uint32 failed";
-        goto exit;
-    }
+        sub   = qd_parse_sub_value(parsed, 1);
+        typed = qd_parse_typed_field(sub);
+        raw   = qd_parse_raw_field(sub);
+        if (!qd_buffer_field_octet(&typed, &octet) || octet != qd_parse_tag(sub)) {
+            result = "sub 1: failed typed";
+            goto exit;
+        }
+        if (octet != QD_AMQP_UINT || raw.remaining != 4) {
+            result = "sub 1: unexpected type";
+            goto exit;
+        }
+        uint32_t uint_read;
+        if (!qd_buffer_field_uint32(&raw, &uint_read) || uint_read != uint_val) {
+            result = "sub 1: uint32 failed";
+            goto exit;
+        }
 
-    sub = qd_parse_sub_value(parsed, 2);
-    typed = qd_parse_typed_field(sub);
-    raw = qd_parse_raw_field(sub);
-    if (!qd_buffer_field_octet(&typed, &octet)
-        || octet != qd_parse_tag(sub)) {
-        result = "sub 2: failed typed";
-        goto exit;
-    }
+        sub   = qd_parse_sub_value(parsed, 2);
+        typed = qd_parse_typed_field(sub);
+        raw   = qd_parse_raw_field(sub);
+        if (!qd_buffer_field_octet(&typed, &octet) || octet != qd_parse_tag(sub)) {
+            result = "sub 2: failed typed";
+            goto exit;
+        }
 
-    if (raw.remaining != 0) {
-        result = "sub 2: non-empty null raw value";
-        goto exit;
+        if (raw.remaining != 0) {
+            result = "sub 2: non-empty null raw value";
+            goto exit;
+        }
     }
 
 exit:


### PR DESCRIPTION
The bulk of the compilation problems (that `-fpermissive` does not suppress) is the different scoping in C and C++ regarding goto labels:

```
/home/jdanek/repos/skupper-router/tests/buffer_test.c: In function ‘char* test_buffer_field(void*)’:
/home/jdanek/repos/skupper-router/tests/buffer_test.c:366:1: error: jump to label ‘exit’
  366 | exit:
      | ^~~~
/home/jdanek/repos/skupper-router/tests/buffer_test.c:327:14: note:   from here
  327 |         goto exit;
      |              ^~~~
/home/jdanek/repos/skupper-router/tests/buffer_test.c:330:14: note:   crosses initialization of ‘uint32_t cmp_count’
  330 |     uint32_t cmp_count = 0;
      |              ^~~~~~~~~
```

Other issues (easy to suppress) are around C++ being more strict regarding `void *` values (that require explicit casts).

I have a list of hopeful directions that C++ compilation might enable, but so far no real results from that, except for some small enhancements that were found while doing this

* https://github.com/skupperproject/skupper-router/pull/249
* https://github.com/skupperproject/skupper-router/pull/248
* https://github.com/skupperproject/skupper-router/pull/247
* https://github.com/skupperproject/skupper-router/pull/211
* https://github.com/skupperproject/skupper-router/pull/82
* https://github.com/skupperproject/skupper-router/pull/1040
* https://github.com/skupperproject/skupper-router/pull/1039
* https://github.com/skupperproject/skupper-router/issues/1038

and 3rd party

* https://github.com/google/sanitizers/issues/1504

One thing I wanted to do with this was to experiment with datastructures (premade hashtables, etc, are more conveniently available in C++ than in C).

The PR does not seem to be too hard to keep up-to-date. I hope to do that for a while, and try something out with it.

Clang does not support -fpermissive.