### PR TITLE
Fixed #296: Remove version property and update other properties in RAT's pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,24 +22,23 @@
       <artifactId>apache</artifactId>
       <version>24</version>
     </parent>
-  
+
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.apache.qpid</groupId>
-    <artifactId>qpid-dispatch</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
-    <name>QpidDispatch</name>
+    <groupId>io.skupper</groupId>
+    <artifactId>router</artifactId>
+    <name>SkupperRouter</name>
     <inceptionYear>2018</inceptionYear>
-    <url>https://qpid.apache.org</url>   
-    
+    <url>https://skupper.io/</url>
+
     <description>
-      Qpid Dispatch Router
+      Skupper Router
     </description>
-    
+
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>   
-    
+    </properties>
+
     <build>
         <defaultGoal>verify</defaultGoal>
         <pluginManagement>
@@ -58,7 +57,7 @@
                    </executions>
               </plugin>
             </plugins>
-        </pluginManagement>        
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.rat</groupId>
@@ -127,8 +126,8 @@
                       <exclude>**/*_pb2*</exclude>
                       <exclude>share/index.html</exclude>
                 </excludes>
-        </configuration>            
+        </configuration>
             </plugin>
-        </plugins>        
-    </build>  
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
       <groupId>org.apache</groupId>
       <artifactId>apache</artifactId>
-      <version>24</version>
+      <version>25</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
                     <excludes>
-                      <exclude>.travis.yml</exclude>
                       <exclude>CMakeCache.txt</exclude>
                       <exclude>.gitmodules</exclude>
                       <exclude>.gitignore</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -69,22 +69,6 @@
                       <exclude>.gitmodules</exclude>
                       <exclude>.gitignore</exclude>
                       <exclude>.autotools</exclude>
-                      <exclude>**/angular-patternfly.min.js</exclude>
-                      <exclude>**/angular-patternfly.min.css</exclude>
-                      <exclude>**/d3.v3.min.js</exclude>
-                      <exclude>**/jquery.tipsy.js</exclude>
-                      <exclude>**/jquery.tipsy.js</exclude>
-                      <exclude>**/zd3-queue.min.js</exclude>
-                      <exclude>**/d3.min.js</exclude>
-                      <exclude>**/tooltipsy.min.js</exclude>
-                      <exclude>**/font-awesome.min.css</exclude>
-                      <exclude>**/jquery-ui.css</exclude>
-                      <exclude>**/jquery.tipsy.css</exclude>
-    	              <exclude>**/vendor.min.js</exclude>
-		      <exclude>**/vendor.min.css</exclude>
-                      <exclude>**/jquery.dynatree.min.js</exclude>
-                      <exclude>**/slider.js</exclude>
-                      <exclude>**/ui-grid.js</exclude>
                       <exclude>**/system_tests_http.txt</exclude>
                       <exclude>**/build/</exclude>
                       <exclude>**/target/</exclude>
@@ -99,7 +83,6 @@
                       <exclude>**/*.json.in</exclude>
                       <exclude>**/*.json</exclude>
                       <exclude>**/*.svg</exclude>
-                      <exclude>**/rhea-min.js</exclude>
                       <exclude>**/VERSION.txt</exclude>
                       <exclude>**/v3_ca.ext</exclude>
                       <exclude>**/system_test.dir/**</exclude>


### PR DESCRIPTION
Alternative approach to what was suggested. Remove the version property from pom.xml so that the file does not have to be touched for updates.

From my own experience, RAT helps to keep me honest when it comes to licence headers, and I would miss it if it goeth away.