### PR TITLE
Enable 🌈colourful🎨 output in GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -189,6 +189,8 @@ jobs:
       LD_LIBRARY_PATH: ${{github.workspace}}/install/lib
       QPID_SYSTEM_TEST_TIMEOUT: 300
       QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST: True
+      # this enables colored output
+      FORCE_COLOR: 1
 
     steps:
 
@@ -317,6 +319,8 @@ jobs:
       RouterBuildDir: ${{github.workspace}}/skupper-router/build
       InstallPrefix: ${{github.workspace}}/install
       RouterCTestExtraArgs: ""
+      # this enables colored output
+      FORCE_COLOR: 1
 
       # TODO(DISPATCH-2144) use -DPython_EXECUTABLE=/usr/bin/python3-debug when issue is fixed,
       #  as that allows for -DSANITIZE_3RD_PARTY=ON on Fedora
@@ -514,6 +518,8 @@ jobs:
       InstallPrefix: ${{github.workspace}}/install
       DispatchCMakeExtraArgs: >
         -GNinja
+      # this enables colored output
+      FORCE_COLOR: 1
 
     steps:
 


### PR DESCRIPTION
Ooo, shiny!

![image](https://user-images.githubusercontent.com/442720/162623914-362cdcf5-709a-4a45-8ff1-ea157f6ce2e1.png)

The disadvantage is that the ANSI escape characters for terminal colors appear in the raw GHA logs.

```
2022-04-10T14:17:54.5774565Z 37: ==================================== ERRORS ====================================
2022-04-10T14:17:54.5778925Z 37: [31m[1m________________________ ERROR collecting test session _________________________[0m
2022-04-10T14:17:54.5783471Z 37: [31mImportError while importing test module '/home/runner/work/skupper-router/skupper-router/skupper-router/tests/system_tests_delivery_counts.py'.
2022-04-10T14:17:54.5787311Z 37: Hint: make sure your test modules/packages have valid Python names.
2022-04-10T14:17:54.5790969Z 37: Traceback:
2022-04-10T14:17:54.5794775Z 37: [1m[31m/usr/lib64/python3.10/importlib/__init__.py[0m:126: in import_module
2022-04-10T14:17:54.5799749Z 37:     return _bootstrap._gcd_import(name[level:], package, level)
2022-04-10T14:17:54.5804992Z 37: [1m[31m/home/runner/work/skupper-router/skupper-router/skupper-router/tests/system_tests_delivery_counts.py[0m:20: in <module>
2022-04-10T14:17:54.5838247Z 37:     from proton import Message, Delivery
2022-04-10T14:17:54.5838810Z 37: [1m[31m/usr/local/lib64/python3.10/site-packages/proton/__init__.py[0m:35: in <module>
2022-04-10T14:17:54.5839206Z 37:     from cproton import PN_VERSION_MAJOR, PN_VERSION_MINOR, PN_VERSION_POINT
2022-04-10T14:17:54.5839821Z 37: [1m[31mE   ImportError: cannot import name 'PN_VERSION_MAJOR' from 'cproton' (/usr/local/lib64/python3.10/site-packages/cproton.py)[0m[0m
2022-04-10T14:17:54.5840487Z 37: - generated xml file: /__w/skupper-router/skupper-router/skupper-router/build/tests/junitxmls/system_tests_delivery_counts.xml -
2022-04-10T14:17:54.5840916Z 37: =========================== short test summary info ============================
2022-04-10T14:17:54.5841160Z 37: ERROR 
2022-04-10T14:17:54.5841433Z 37: !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
2022-04-10T14:17:54.5841868Z 37: [31m=============================== [31m[1m1 error[0m[31m in 0.17s[0m[31m ===============================[0m
2022-04-10T14:17:54.5869747Z 39: [1mcollecting ... [0mcollected 0 items / 1 error
```