### PR TITLE
Revert "Workaround Proton build issues by building with `make` and `--parallel 1`"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,10 +122,11 @@ jobs:
           cmake "${{github.workspace}}/qpid-proton" \
             "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" \
             "-DCMAKE_BUILD_TYPE=${BuildType}" \
+            "-GNinja" \
             ${ProtonCMakeExtraArgs}
 
       - name: qpid-proton cmake build/install
-        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} -t install --parallel 1
+        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} -t install --parallel 6
 
       - name: Display ccache stats
         run: ccache -s
@@ -408,7 +409,7 @@ jobs:
             ${ProtonCMakeExtraArgs}
 
       - name: qpid-proton cmake build/install
-        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} --target install --parallel 1
+        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} --target install --parallel 6
 
       - name: Display ccache stats
         run: ccache -s


### PR DESCRIPTION
Issues fixed in https://github.com/apache/qpid-proton/commit/14dd9b9da7bf15f191e9175ca80050d4211f4b65

Reverts skupperproject/skupper-router#318