### PR TITLE
Fixes #331: DISPATCH-2276: Accommodate hex values in 0.36+ qpid-proton logging (#1525)

### DIFF
--- a/tests/system_tests_topology_disposition.py
+++ b/tests/system_tests_topology_disposition.py
@@ -23,7 +23,6 @@ import time
 import unittest
 from subprocess import PIPE, STDOUT
 
-import proton
 from proton import Message
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
@@ -406,7 +405,6 @@ class TopologyDispositionTests (TestCase):
                 self.assertIsNone(error)
             self.assertIsNone(error)
 
-    @unittest.skipIf(proton.VERSION > (0, 36, 0), "see DISPATCH-2276")
     def test_04_scraper_tool(self):
         name = 'test_04'
         error = str(None)

--- a/tools/scraper/amqp_detail.py
+++ b/tools/scraper/amqp_detail.py
@@ -677,7 +677,7 @@ class AllDetails():
                             sdispmap = sess.rx_rcvr_disposition_map if splf.data.is_receiver else sess.rx_sndr_disposition_map
                         else:
                             sdispmap = sess.tx_rcvr_disposition_map if splf.data.is_receiver else sess.tx_sndr_disposition_map
-                        for sdid in range(int(splf.data.first), (int(splf.data.last) + 1)):
+                        for sdid in range(int(splf.data.first, 0), (int(splf.data.last, 0) + 1)):
                             did = str(sdid)
                             if did in sdispmap:
                                 old_splf = sdispmap[did]
@@ -825,7 +825,7 @@ class AllDetails():
                                     tod_of_second_attach = plf.datetime
                         if look_for_sender_delivery_id:
                             if plf.data.name == "attach" and not plf.data.is_receiver:
-                                current_delivery = int(plf.data.described_type.dict.get("initial-delivery_count", "0"))
+                                current_delivery = int(plf.data.described_type.dict.get("initial-delivery_count", "0"), 0)
                                 delivery_limit = current_delivery
                                 look_for_sender_delivery_id = False
 
@@ -834,7 +834,7 @@ class AllDetails():
                                 # a flow in the normal direction updates the delivery limit
                                 dc = plf.data.described_type.dict.get("delivery-count", "0")
                                 lc = plf.data.described_type.dict.get("link-credit", "0")
-                                delivery_limit = int(dc) + int(lc)  # TODO: wrap at 32-bits
+                                delivery_limit = int(dc, 0) + int(lc, 0)  # TODO: wrap at 32-bits
                                 if n_attaches < 2:
                                     # a working flow before sender attach - cancel initial stall
                                     init_stall = False
@@ -854,7 +854,7 @@ class AllDetails():
                             else:
                                 # flow in the opposite direction updates the senders current delivery
                                 # normally used to consume credit in response to a drain from receiver
-                                current_delivery = int(plf.data.described_type.dict.get("initial-delivery_count", "0"))
+                                current_delivery = int(plf.data.described_type.dict.get("initial-delivery_count", "0"), 0)
 
                         elif plf.data.transfer:
                             if plf.data.direction == dir_of_xfer:

--- a/tools/scraper/parser.py
+++ b/tools/scraper/parser.py
@@ -296,6 +296,9 @@ class DescribedType:
             if '=' not in fields[0]:
                 raise ValueError("Field does not contain equal sign '%s'" % fields[0])
             key, val = DescribedType.get_key_and_val(fields[0])
+            # New proton logging uses hex strings. Convert to decimal strings.
+            if val.startswith("0x"):
+                val = str(int(val, 0))
             del fields[0]
             if DescribedType.is_dtype_name(val):
                 # recursing to process subtype


### PR DESCRIPTION
DISPATCH-2276: Accommodate hex values in 0.36+ qpid-proton logging

* Fix code that extracts integer values during AMQP analysis
* Convert ints from hex to decimal for web display of values line
  link and session numbers and credit.

DISPATCH-2276: Topology disposition test does not need to import proton

Co-authored-by: chug <chug@taj.localdomain>
Co-authored-by: Chuck Rolke <chug@apache.org>