### PR TITLE
[WIP] Fixes #339 - Print source file and line number in alloc_pool leak backtraces automatically

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Install Linux build dependencies
         run: |
-          sudo apt update; sudo apt install -y swig libpython3-dev libsasl2-dev libjsoncpp-dev libwebsockets-dev libnghttp2-dev ccache ninja-build pixz libbenchmark-dev
+          sudo apt update; sudo apt install -y binutils-dev swig libpython3-dev libsasl2-dev libjsoncpp-dev libwebsockets-dev libnghttp2-dev ccache ninja-build pixz libbenchmark-dev
 
       - name: Zero ccache stats
         run: ccache -z
@@ -436,7 +436,7 @@ jobs:
 
       - name: Install Linux build dependencies
         run: |
-          dnf install -y gcc gcc-c++ cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain swig python3-devel python3-pip make libwebsockets-devel libnghttp2-devel ccache libasan libubsan libtsan
+          dnf install -y gcc gcc-c++ binutils-devel cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain swig python3-devel python3-pip make libwebsockets-devel libnghttp2-devel ccache libasan libubsan libtsan
 
       - name: Install Python build dependencies
         run: python3 -m pip install setuptools wheel tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ addons:
       # Dispatch requirements
       - libnghttp2-dev
       - libwebsockets-dev
+      # backtrace symbolization
+      - binutils-dev
       # code coverage
       - lcov
       # tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,8 @@ find_package(LibWebSockets 4.0.1 REQUIRED)
 ## Optional dependencies
 ##
 
+find_library(bfd_lib bfd DOC "libdfd used to symbolize QD_MEMORY_DEBUG backtraces")
+
 # google benchmark tests are disabled by default
 OPTION(BUILD_BENCHMARKS "Enable building and running benchmarks with Google Benchmark" OFF)
 

--- a/include/qpid/dispatch/internal/symbolization.h
+++ b/include/qpid/dispatch/internal/symbolization.h
@@ -33,7 +33,7 @@ typedef struct qd_backtrace_fileline {
 
 void qd_symbolize_finalize();
 
-void print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_symbolization, int i, void *pc);
+void qd_print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_symbolization, int i, void *pc);
 qd_backtrace_fileline_t qd_symbolize_backtrace_line(bfd_vma pc);
 
 #endif  // QPID_DISPATCH_SYMBOLIZATION_H

--- a/include/qpid/dispatch/internal/symbolization.h
+++ b/include/qpid/dispatch/internal/symbolization.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef QPID_DISPATCH_SYMBOLIZATION_H
+#define QPID_DISPATCH_SYMBOLIZATION_H
+
+#include <bfd.h>
+#include <stdio.h>
+
+typedef struct qd_backtrace_fileline {
+    bool found;
+    const char *sourcefile;
+    const char *funcname;
+    unsigned int line;
+} qd_backtrace_fileline_t;
+
+void qd_symbolize_finalize();
+
+void print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_symbolization, int i, void *pc);
+qd_backtrace_fileline_t qd_symbolize_backtrace_line(bfd_vma pc);
+
+#endif  // QPID_DISPATCH_SYMBOLIZATION_H

--- a/include/qpid/dispatch/internal/symbolization.h
+++ b/include/qpid/dispatch/internal/symbolization.h
@@ -21,6 +21,7 @@
 #define QPID_DISPATCH_SYMBOLIZATION_H
 
 #include <bfd.h>
+#include <stdbool.h>
 #include <stdio.h>
 
 typedef struct qd_backtrace_fileline {

--- a/include/qpid/dispatch/internal/symbolization.h
+++ b/include/qpid/dispatch/internal/symbolization.h
@@ -35,5 +35,6 @@ void qd_symbolize_finalize();
 
 void qd_print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_symbolization, int i, void *pc);
 qd_backtrace_fileline_t qd_symbolize_backtrace_line(bfd_vma pc);
+int main2();
 
 #endif  // QPID_DISPATCH_SYMBOLIZATION_H

--- a/include/qpid/dispatch/internal/symbolization.h
+++ b/include/qpid/dispatch/internal/symbolization.h
@@ -28,7 +28,7 @@ typedef struct qd_backtrace_fileline {
     bool found;
     const char *sourcefile;
     const char *funcname;
-    unsigned int line;
+    int line;
 } qd_backtrace_fileline_t;
 
 void qd_symbolize_finalize();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,7 +155,7 @@ set(qpid_dispatch_LIBRARIES
   ${Proton_Tls_LIBRARIES}
   ${Python_LIBRARIES}
   ${rt_lib}
-  -lbfd
+  ${bfd_lib}
   ${CMAKE_DL_LIBS}
   ${Python_LIBRARIES}
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ set(qpid_dispatch_SOURCES
   policy_spec.c
   protocol_adaptor.c
   proton_utils.c
+  posix/symbolization.c
   posix/threading.c
   python_embedded.c
   router_agent.c
@@ -154,6 +155,9 @@ set(qpid_dispatch_LIBRARIES
   ${Proton_Tls_LIBRARIES}
   ${Python_LIBRARIES}
   ${rt_lib}
+  -lbfd
+  ${CMAKE_DL_LIBS}
+  ${Python_LIBRARIES}
   )
 
 if ((DEFINED ASAN_LIBRARY) OR (DEFINED UBSAN_LIBRARY) OR (DEFINED TSAN_LIBRARY))

--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -37,6 +37,8 @@
 #ifdef QD_MEMORY_DEBUG
 #include "log_private.h"
 
+#include "qpid/dispatch/internal/symbolization.h"
+
 #include <execinfo.h>
 #endif
 
@@ -643,11 +645,12 @@ void qd_alloc_finalize(void)
                     qd_log_formatted_time(&item->timestamp, buf, 100);
                     fprintf(dump_file, "Leak: %s type: %s address: %p\n",
                             buf, desc->type_name, (void *)(&item[1]));
-                    for (size_t i = 0; i < item->backtrace_size; i++)
-                        fprintf(dump_file, "%s\n", strings[i]);
+                    for (int i = 0; i < item->backtrace_size; i++)
+                        print_symbolized_backtrace_line(dump_file, strings[i], i, item->backtrace[i]);
                     fprintf(dump_file, "\n");
                     last_leak = desc->type_name;
                 }
+                qd_symbolize_finalize();
                 free(strings);
 
                 // free the item to prevent ASAN from also reporting this leak.

--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -646,7 +646,7 @@ void qd_alloc_finalize(void)
                     fprintf(dump_file, "Leak: %s type: %s address: %p\n",
                             buf, desc->type_name, (void *)(&item[1]));
                     for (int i = 0; i < item->backtrace_size; i++)
-                        print_symbolized_backtrace_line(dump_file, strings[i], i, item->backtrace[i]);
+                        qd_print_symbolized_backtrace_line(dump_file, strings[i], i, item->backtrace[i]);
                     fprintf(dump_file, "\n");
                     last_leak = desc->type_name;
                 }

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -591,7 +591,7 @@ unsigned char qd_iterator_octet(qd_iterator_t *iter)
 
         unsigned char result;
         if (iter->view_pointer.buffer) {
-            uint8_t octet;
+            uint8_t octet=0;
             (void)qd_buffer_field_octet(&iter->view_pointer, &octet);
             result = (unsigned char) octet;
         } else { // string or binary array

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -136,7 +136,7 @@ void qd_symbolize_finalize()
     }
     state.abfd = NULL;
 
-    bfd_cache_close_all();
+//    bfd_cache_close_all();
 
 //    state.libbfd_inited = false;
 }

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -93,9 +93,9 @@ qd_backtrace_fileline_t qd_symbolize_backtrace_line(bfd_vma pc)
         const char * funcname; // throwaway, but bfd_find_nearest_line does not accept NULL
         if (result.found) continue;
         result.found = bfd_find_nearest_line(state.abfd, section, &state.syms, pc - vma, &result.sourcefile,
-                                             &funcname, &result.line);
+                                             &funcname, (unsigned int *)&result.line);
 
-//        if (result.found) break;
+        if (result.found) break;
     }
 
 finalize:

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -124,4 +124,6 @@ void qd_symbolize_finalize()
         bfd_close(state.abfd);
     }
     state.abfd = NULL;
+
+    state.libbfd_inited = false;
 }

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -33,6 +33,414 @@ static struct {
     asymbol *syms;  ///< syms holds symbol table from the object
 } state = {0};
 
+
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define _GNU_SOURCE
+
+#include <assert.h>
+#include <bfd.h>
+#include <dlfcn.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <demangle.h>
+
+
+/* These global variables are used to pass information between
+   translate_addresses and find_address_in_section.  */
+
+static bfd_vma pc;
+static const char *filename;
+static const char *functionname;
+static unsigned int line;
+static unsigned int discriminator;
+static bool found;
+
+#define DEBUG printf
+//static bfd *abfd      = NULL;
+static asymbol **syms = NULL;
+
+const char * program_name = "program name";
+
+static void
+find_address_in_section (bfd *abfd, asection *section,
+                        void *data ATTRIBUTE_UNUSED)
+{
+    bfd_vma vma;
+    bfd_size_type size;
+
+    if (found)
+        return;
+
+    if ((bfd_section_flags (section) & SEC_ALLOC) == 0)
+        return;
+
+    vma = bfd_section_vma (section);
+    if (pc < vma)
+        return;
+
+    size = bfd_section_size (section);
+    if (pc >= vma + size)
+        return;
+
+    found = bfd_find_nearest_line_discriminator (abfd, section, syms, pc - vma,
+                                                &filename, &functionname,
+                                                &line, &discriminator);
+}
+
+
+static int naddr = 1;		/* Number of addresses to process.  */
+//const static char* first = "0x123";
+static char *arr[] = {"first"};
+static char **addr = arr;		/* Hex addresses to process.  */
+bool unwind_inlines = false;
+static bool base_names = false;		/* -s, strip directory names.  */
+static bool pretty_print = true;
+static bool with_addresses = true;
+static bool with_functions = true;
+static bool do_demangle = true;
+
+static asymbol **syms;		/* Symbol table.  */
+
+/* Flags passed to the name demangler.  */
+static int demangle_flags = DMGL_PARAMS | DMGL_ANSI;
+
+/* Look for an offset in a section.  This is directly called.  */
+
+static void
+find_offset_in_section (bfd *abfd, asection *section)
+{
+    bfd_size_type size;
+
+    if (found)
+        return;
+
+    if ((bfd_section_flags (section) & SEC_ALLOC) == 0)
+        return;
+
+    size = bfd_section_size (section);
+    if (pc >= size)
+        return;
+
+    found = bfd_find_nearest_line_discriminator (abfd, section, syms, pc,
+                                                &filename, &functionname,
+                                                &line, &discriminator);
+}
+
+/* Read hexadecimal addresses from stdin, translate into
+   file_name:line_number and optionally function name.  */
+
+static void
+translate_addresses (bfd *abfd, asection *section)
+{
+    int read_stdin = (naddr == 0);
+
+    for (;;)
+    {
+        if (read_stdin)
+        {
+            char addr_hex[100];
+
+            if (fgets (addr_hex, sizeof addr_hex, stdin) == NULL)
+                break;
+            pc = bfd_scan_vma (addr_hex, NULL, 16);
+        }
+        else
+        {
+            if (naddr <= 0)
+                break;
+            --naddr;
+            pc = bfd_scan_vma (*addr++, NULL, 16);
+        }
+
+        if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
+        {
+            //            const struct elf_backend_data *bed = get_elf_backend_data (abfd);
+            //            bfd_vma sign = (bfd_vma) 1 << (bed->s->arch_size - 1);
+            //
+            //            pc &= (sign << 1) - 1;
+            //            if (bed->sign_extend_vma)
+            //                pc = (pc ^ sign) - sign;
+        }
+
+        if (with_addresses)
+        {
+            printf ("0x");
+            bfd_printf_vma (abfd, pc);
+
+            if (pretty_print)
+                printf (": ");
+            else
+                printf ("\n");
+        }
+
+        found = false;
+        if (section)
+            find_offset_in_section (abfd, section);
+        else
+            bfd_map_over_sections (abfd, find_address_in_section, NULL);
+
+        if (! found)
+        {
+            if (with_functions)
+            {
+                if (pretty_print)
+                    printf ("?? ");
+                else
+                    printf ("??\n");
+            }
+            printf ("??:0\n");
+        }
+        else
+        {
+            while (1)
+            {
+                if (with_functions)
+                {
+                    const char *name;
+                    char *alloc = NULL;
+
+                    name = functionname;
+                    if (name == NULL || *name == '\0')
+                        name = "??";
+                    else if (do_demangle)
+                    {
+                        alloc = bfd_demangle (abfd, name, demangle_flags);
+                        if (alloc != NULL)
+                            name = alloc;
+                    }
+
+                    printf ("%s", name);
+                    if (pretty_print)
+                        /* Note for translators:  This printf is used to join the
+                           function name just printed above to the line number/
+                           file name pair that is about to be printed below.  Eg:
+
+                             foo at 123:bar.c  */
+                        printf (" at ");
+                    else
+                        printf ("\n");
+
+                    free (alloc);
+                }
+
+                if (base_names && filename != NULL)
+                {
+                    char *h;
+
+                    h = strrchr (filename, '/');
+                    if (h != NULL)
+                        filename = h + 1;
+                }
+
+                printf ("%s:", filename ? filename : "??");
+                if (line != 0)
+                {
+                    if (discriminator != 0)
+                        printf ("%u (discriminator %u)\n", line, discriminator);
+                    else
+                        printf ("%u\n", line);
+                }
+                else
+                    printf ("?\n");
+                if (!unwind_inlines)
+                    found = false;
+                else
+                    found = bfd_find_inliner_info (abfd, &filename, &functionname,
+                                                  &line);
+                if (! found)
+                    break;
+                if (pretty_print)
+                    /* Note for translators: This printf is used to join the
+                       line number/file name pair that has just been printed with
+                       the line number/file name pair that is going to be printed
+                       by the next iteration of the while loop.  Eg:
+
+                         123:bar.c (inlined by) 456:main.c  */
+                    printf (" (inlined by) ");
+            }
+        }
+
+        /* fflush() is essential for using this command as a server
+           child process that reads addresses from a pipe and responds
+           with line number information, processing one address at a
+           time.  */
+        fflush (stdout);
+    }
+}
+
+/* After a FALSE return from bfd_check_format_matches with
+   bfd_get_error () == bfd_error_file_ambiguously_recognized, print
+   the possible matching targets.  */
+
+void
+list_matching_formats (char **p)
+{
+    fflush (stdout);
+    fprintf (stderr, "%s: Matching formats:", program_name);
+    while (*p)
+        fprintf (stderr, " %s", *p++);
+    fputc ('\n', stderr);
+}
+
+void
+bfd_nonfatal (const char *string)
+{
+    const char *errmsg;
+    enum bfd_error err = bfd_get_error ();
+
+    if (err == bfd_error_no_error)
+        errmsg = "cause of error unknown";
+    else
+        errmsg = bfd_errmsg (err);
+    fflush (stdout);
+    if (string)
+        fprintf (stderr, "%s: %s: %s\n", program_name, string, errmsg);
+    else
+        fprintf (stderr, "%s: %s\n", program_name, errmsg);
+}
+
+void
+bfd_fatal (const char *string)
+{
+    bfd_nonfatal (string);
+    exit (1);
+}
+
+/* Read in the symbol table.  */
+
+static void
+slurp_symtab (bfd *abfd)
+{
+    long storage;
+    long symcount;
+    bool dynamic = false;
+
+    if ((bfd_get_file_flags (abfd) & HAS_SYMS) == 0)
+        return;
+
+    storage = bfd_get_symtab_upper_bound (abfd);
+    if (storage == 0)
+    {
+        storage = bfd_get_dynamic_symtab_upper_bound (abfd);
+        dynamic = true;
+    }
+    if (storage < 0)
+        bfd_fatal (bfd_get_filename (abfd));
+
+    syms = (asymbol **) malloc (storage);
+    if (dynamic)
+        symcount = bfd_canonicalize_dynamic_symtab (abfd, syms);
+    else
+        symcount = bfd_canonicalize_symtab (abfd, syms);
+    if (symcount < 0)
+        bfd_fatal (bfd_get_filename (abfd));
+
+    /* If there are no symbols left after canonicalization and
+       we have not tried the dynamic symbols then give them a go.  */
+    if (symcount == 0
+        && ! dynamic
+        && (storage = bfd_get_dynamic_symtab_upper_bound (abfd)) > 0)
+    {
+        free (syms);
+        syms = xmalloc (storage);
+        symcount = bfd_canonicalize_dynamic_symtab (abfd, syms);
+    }
+
+    /* PR 17512: file: 2a1d3b5b.
+       Do not pretend that we have some symbols when we don't.  */
+    if (symcount <= 0)
+    {
+        free (syms);
+        syms = NULL;
+    }
+}
+
+const char *section_name;
+
+int main2() {
+    //    const qd_backtrace_fileline_t res = qd_symbolize_backtrace_line((bfd_vma) main);
+    //    printf("%s:%d\n", res.funcname, res.line);
+    //    free(res.funcname);
+    //    qd_symbolize_finalize();
+
+    //    char * string;
+    //    debug_sigInit();
+    //    debug_translateAddress(string, (bfd_vma) (bfd_hostptr_t) main);
+    //    free(string);
+    //    debug_sigClose();
+
+    bfd *abfd;
+    asection *section;
+    char **matching;
+    char *file_name = "/proc/self/exe";
+
+    //    if (get_file_size (file_name) < 1)
+    //        return 1;
+
+    abfd = bfd_openr (file_name, NULL);
+    if (abfd == NULL)
+        //        bfd_fatal (file_name);
+        ;
+
+    /* Decompress sections.  */
+    abfd->flags |= BFD_DECOMPRESS;
+
+    if (bfd_check_format (abfd, bfd_archive))
+        printf ("%s: cannot get addresses from archive", file_name);
+
+    if (! bfd_check_format_matches (abfd, bfd_object, &matching))
+    {
+        bfd_nonfatal (bfd_get_filename (abfd));
+        if (bfd_get_error () == bfd_error_file_ambiguously_recognized)
+        {
+            list_matching_formats (matching);
+            free (matching);
+        }
+        xexit (1);
+    }
+
+    if (section_name != NULL)
+    {
+        section = bfd_get_section_by_name (abfd, section_name);
+        if (section == NULL)
+            printf ("%s: cannot find section %s", file_name, section_name);
+    }
+    else
+        section = NULL;
+
+    slurp_symtab (abfd);
+
+    translate_addresses (abfd, section);
+
+    free (syms);
+    syms = NULL;
+
+    bfd_close (abfd);
+
+    return 0;
+}
+
+
 ///
 qd_backtrace_fileline_t qd_symbolize_backtrace_line(bfd_vma pc)
 {

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -108,10 +108,6 @@ find_address_in_section (bfd *abfd, asection *section,
 }
 
 
-static int naddr = 1;		/* Number of addresses to process.  */
-//const static char* first = "0x123";
-static char *arr[] = {"first"};
-static char **addr = arr;		/* Hex addresses to process.  */
 bool unwind_inlines = false;
 static bool base_names = false;		/* -s, strip directory names.  */
 static bool pretty_print = true;
@@ -152,25 +148,7 @@ find_offset_in_section (bfd *abfd, asection *section)
 static void
 translate_addresses (bfd *abfd, asection *section)
 {
-    int read_stdin = (naddr == 0);
-
-    for (;;)
-    {
-        if (read_stdin)
-        {
-            char addr_hex[100];
-
-            if (fgets (addr_hex, sizeof addr_hex, stdin) == NULL)
-                break;
-            pc = bfd_scan_vma (addr_hex, NULL, 16);
-        }
-        else
-        {
-            if (naddr <= 0)
-                break;
-            --naddr;
-            pc = bfd_scan_vma (*addr++, NULL, 16);
-        }
+            pc = (bfd_vma) &translate_addresses;
 
         if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
         {
@@ -285,7 +263,7 @@ translate_addresses (bfd *abfd, asection *section)
            with line number information, processing one address at a
            time.  */
         fflush (stdout);
-    }
+
 }
 
 /* After a FALSE return from bfd_check_format_matches with
@@ -419,13 +397,13 @@ int main2() {
         xexit (1);
     }
 
-    if (section_name != NULL)
-    {
-        section = bfd_get_section_by_name (abfd, section_name);
-        if (section == NULL)
-            printf ("%s: cannot find section %s", file_name, section_name);
-    }
-    else
+//    if (section_name != NULL)
+//    {
+//        section = bfd_get_section_by_name (abfd, section_name);
+//        if (section == NULL)
+//            printf ("%s: cannot find section %s", file_name, section_name);
+//    }
+//    else
         section = NULL;
 
     slurp_symtab (abfd);

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -84,8 +84,9 @@ qd_backtrace_fileline_t qd_symbolize_backtrace_line(bfd_vma pc)
 #endif
         if (pc >= vma + size) continue;
 
+        const char * funcname; // throwaway, but bfd_find_nearest_line does not accept NULL
         result.found = bfd_find_nearest_line(state.abfd, section, &state.syms, pc - vma, &result.sourcefile,
-                                             NULL, &result.line);
+                                             &funcname, &result.line);
 
         if (result.found) break;
     }
@@ -100,7 +101,7 @@ finalize:
     return result;
 }
 
-void print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_symbolization, int i, void *pc)
+void qd_print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_symbolization, int i, void *pc)
 {
     // attempt to symbolize the address
 

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -62,8 +62,7 @@ static struct {
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <demangle.h>
-
+//#include <demangle.h>
 
 /* These global variables are used to pass information between
    translate_addresses and find_address_in_section.  */
@@ -117,8 +116,8 @@ static bool do_demangle = true;
 
 static asymbol **syms;		/* Symbol table.  */
 
-/* Flags passed to the name demangler.  */
-static int demangle_flags = DMGL_PARAMS | DMGL_ANSI;
+///* Flags passed to the name demangler.  */
+// static int demangle_flags = DMGL_PARAMS | DMGL_ANSI;
 
 /* Look for an offset in a section.  This is directly called.  */
 
@@ -202,9 +201,9 @@ translate_addresses (bfd *abfd, asection *section)
                         name = "??";
                     else if (do_demangle)
                     {
-                        alloc = bfd_demangle (abfd, name, demangle_flags);
-                        if (alloc != NULL)
-                            name = alloc;
+                        //                        alloc = bfd_demangle (abfd, name, demangle_flags);
+                        //                        if (alloc != NULL)
+                        //                            name = alloc;
                     }
 
                     printf ("%s", name);

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -339,7 +339,7 @@ slurp_symtab (bfd *abfd)
         && (storage = bfd_get_dynamic_symtab_upper_bound (abfd)) > 0)
     {
         free (syms);
-        syms = xmalloc (storage);
+        syms     = malloc(storage);
         symcount = bfd_canonicalize_dynamic_symtab (abfd, syms);
     }
 
@@ -393,7 +393,7 @@ int main2() {
             list_matching_formats (matching);
             free (matching);
         }
-        xexit (1);
+        exit(1);
     }
 
 //    if (section_name != NULL)

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -64,14 +64,14 @@ qd_backtrace_fileline_t qd_symbolize_backtrace_line(bfd_vma pc)
     for (struct bfd_section *section = state.abfd->sections; section != NULL; section = section->next) {
         // use preprocessor to handle pre binutils-2.34 API (on CentOS 8)
 #ifdef bfd_get_section_flags
-        flagword flags = bfd_get_section_flags(abfd, section);
+        flagword flags = bfd_get_section_flags(state.abfd, section);
 #else
         flagword flags = bfd_section_flags(section);
 #endif
         if ((flags & SEC_ALLOC) == 0) continue;
 
 #ifdef bfd_get_section_vma
-        bfd_vma vma = bfd_get_section_vma(abfd, section);
+        bfd_vma vma = bfd_get_section_vma(state.abfd, section);
 #else
         bfd_vma vma = bfd_section_vma(section);
 #endif

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define _GNU_SOURCE
+
+#include "qpid/dispatch/internal/symbolization.h"
+
+#include <bfd.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static struct {
+    bool libbfd_inited;
+    bfd *abfd; ///< abfd is the libbfd handle for open object
+    asymbol *syms; ///< syms holds symbol table from the object
+} state = {0};
+
+///
+qd_backtrace_fileline_t qd_symbolize_backtrace_line(bfd_vma pc)
+{
+    qd_backtrace_fileline_t result;
+    result.found = false;
+
+    if (!state.libbfd_inited) {
+        bfd_init();
+        state.libbfd_inited = true;
+    }
+
+    unsigned int symsize;
+    long symcount;
+
+    if (state.abfd == NULL) {
+        state.abfd = bfd_openr("/proc/self/exe", NULL);
+        state.abfd->flags |= BFD_DECOMPRESS;  // https://sourceware.org/legacy-ml/gdb-patches/2012-10/msg00262.html
+        bfd_boolean res = bfd_check_format(state.abfd, bfd_object);
+        if (!res) goto finalize;
+    }
+
+    if ((bfd_get_file_flags(state.abfd) & HAS_SYMS) == 0) goto finalize;
+
+    symcount = bfd_read_minisymbols(state.abfd, false, (void **) &state.syms, &symsize);
+    if (symcount == 0) symcount = bfd_read_minisymbols(state.abfd, true, (void **) &state.syms, &symsize);
+    if (symcount == 0) goto finalize;
+
+    // loop can be more commonly written using `bfd_map_over_sections` and a callback
+    for (struct bfd_section *section = state.abfd->sections; section != NULL; section = section->next) {
+        if ((bfd_section_flags(section) & SEC_ALLOC) == 0) continue;
+
+        bfd_vma vma = bfd_section_vma(section);
+        if (pc < vma) continue;
+
+        bfd_size_type size = bfd_section_size(section);
+        if (pc >= vma + size) continue;
+
+        result.found =
+            bfd_find_nearest_line(state.abfd, section, &state.syms, pc - vma, &result.sourcefile, &result.funcname, &result.line);
+
+        if (result.found) break;
+    }
+
+finalize:
+    return result;
+}
+
+void print_symbolized_backtrace_line(FILE * dump_file, const char * fallback_symbolization, int i, void * pc) {
+    // attempt to symbolize the address
+    Dl_info info;
+    if (dladdr(pc, &info) != 0) {
+        qd_backtrace_fileline_t res = qd_symbolize_backtrace_line((bfd_vma) pc);
+        if (res.found) {
+            fprintf(dump_file,
+                    "#%d %s %s:%d\n", i, info.dli_sname ? info.dli_sname : "(?""?)", res.sourcefile, res.line);
+            return;
+        }
+    }
+    // symbolization did not succeed, print the uninspiring backtrace_symbols output as fallback
+    fprintf(dump_file, "   %s\n", fallback_symbolization);
+}
+
+void qd_symbolize_finalize() {
+    if (state.syms) {
+        free(state.syms);
+    }
+    state.syms = NULL;
+
+    if (state.abfd) {
+        bfd_close(state.abfd);
+    }
+    state.abfd = NULL;
+}

--- a/tests/c_unittests/CMakeLists.txt
+++ b/tests/c_unittests/CMakeLists.txt
@@ -37,8 +37,8 @@ add_executable(c_unittests
         test_listener_startup.cpp
         test_router_startup.cpp
         test_server.cpp
-        test_terminus.cpp)
-target_link_libraries(c_unittests cpp-stub pthread skupper-router static_accessors_server_c)
+        test_terminus.cpp test_alloc_pool.cpp)
+target_link_libraries(c_unittests cpp-stub pthread skupper-router static_accessors_server_c -lbfd -ldl)
 
 file(COPY
         ${CMAKE_CURRENT_SOURCE_DIR}/minimal_silent.conf

--- a/tests/c_unittests/CMakeLists.txt
+++ b/tests/c_unittests/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(c_unittests
         test_router_startup.cpp
         test_server.cpp
         test_terminus.cpp test_alloc_pool.cpp)
-target_link_libraries(c_unittests cpp-stub pthread skupper-router static_accessors_server_c -lbfd -ldl)
+target_link_libraries(c_unittests cpp-stub pthread skupper-router static_accessors_server_c ${bfd_lib})
 
 file(COPY
         ${CMAKE_CURRENT_SOURCE_DIR}/minimal_silent.conf

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -69,7 +69,7 @@ TEST_CASE("qd_symbolize_backtrace_line")
     };
     CHECK(res.sourcefile == __FILE__);
     CHECK(res.funcname == "probe");
-    CHECK(res.line == probe_line);
+    CHECK(std::abs(probe_line - res.line) <= 3);  // require reasonable precision
     qd_symbolize_finalize();
 }
 

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -62,7 +62,11 @@ void a_calls_b(item &item)
 TEST_CASE("qd_symbolize_backtrace_line")
 {
     const qd_backtrace_fileline_t &res = qd_symbolize_backtrace_line((bfd_vma) probe);
-    printf("found: %s %s %d", res.sourcefile, res.funcname, res.line);
+    REQUIRE(res.found);
+    if(!res.found) {
+        qd_symbolize_finalize();
+        return;
+    };
     CHECK(res.sourcefile == __FILE__);
     CHECK(res.funcname == "probe");
     CHECK(res.line == probe_line);

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "qdr_doctest.hpp"
+
+extern "C" {
+#include "qpid/dispatch/internal/symbolization.h"
+}
+
+#include <bfd.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <stdlib.h>
+
+#include <cstdio>
+
+const int STACK_DEPTH = 10;
+
+struct item {
+    void *backtrace[STACK_DEPTH];
+    int backtrace_size;
+};
+
+extern "C" {
+void b_stores_backtrace(item &item)
+{
+    item.backtrace_size = backtrace(item.backtrace, STACK_DEPTH);
+}
+
+void a_calls_b(item &item)
+{
+    b_stores_backtrace(item);
+}
+}
+
+const char *filename;
+const char *functionname;
+unsigned int line;
+bool found = false;
+
+
+
+// static void find_address_in_section(bfd *abfd, asection *section, void *data __attribute__ ((__unused__)) )
+//{
+//     printf("looping\n");
+//
+//
+// }
+
+
+
+/**
+ * Run this in between ; bfd_close();
+ */
+
+
+void mymapaddr()
+{
+    const qd_backtrace_fileline_t &res = qd_symbolize_backtrace_line((bfd_vma) mymapaddr);
+    printf("found: %s %s %d", res.sourcefile, res.funcname, res.line);
+}
+
+    //
+    //    if (!found) {
+    //        printf("[%s] \?\?() \?\?:0\n",addr[naddr-1]);
+    //    } else {
+    //        const char *name;
+    //
+    //        name = functionname;
+    //        if (name == NULL || *name == '\0')
+    //            name = "??";
+    //        if (filename != NULL) {
+    //            char *h;
+    //
+    //            h = strrchr(filename, '/');
+    //            if (h != NULL)
+    //                filename = h + 1;
+    //        }
+    //
+    //        printf("\t%s:%u\t", filename ? filename : "??",
+    //               line);
+    //
+    //        printf("%s()\n", name);
+    //
+    //    }
+
+void printbt(item &item)
+{
+    char buf[100];
+    char **strings = backtrace_symbols(item.backtrace, item.backtrace_size);
+
+    printf("Leak: %s type: %s address: %p\n", buf, "xxx", (void *) (&item));
+    for (size_t i = 0; i < item.backtrace_size; i++) {
+
+    }
+    printf("\n");
+    free(strings);
+}
+
+TEST_CASE("backtrace")
+{
+    item i;
+
+    a_calls_b(i);
+
+    printbt(i);
+
+    mymapaddr();
+}

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -30,6 +30,9 @@ extern "C" {
 
 #include <cstdio>
 
+namespace test_backtrace
+{
+
 const int STACK_DEPTH = 10;
 
 struct item {
@@ -54,8 +57,6 @@ const char *functionname;
 unsigned int line;
 bool found = false;
 
-
-
 // static void find_address_in_section(bfd *abfd, asection *section, void *data __attribute__ ((__unused__)) )
 //{
 //     printf("looping\n");
@@ -63,12 +64,9 @@ bool found = false;
 //
 // }
 
-
-
 /**
  * Run this in between ; bfd_close();
  */
-
 
 void mymapaddr()
 {
@@ -76,29 +74,29 @@ void mymapaddr()
     printf("found: %s %s %d", res.sourcefile, res.funcname, res.line);
 }
 
-    //
-    //    if (!found) {
-    //        printf("[%s] \?\?() \?\?:0\n",addr[naddr-1]);
-    //    } else {
-    //        const char *name;
-    //
-    //        name = functionname;
-    //        if (name == NULL || *name == '\0')
-    //            name = "??";
-    //        if (filename != NULL) {
-    //            char *h;
-    //
-    //            h = strrchr(filename, '/');
-    //            if (h != NULL)
-    //                filename = h + 1;
-    //        }
-    //
-    //        printf("\t%s:%u\t", filename ? filename : "??",
-    //               line);
-    //
-    //        printf("%s()\n", name);
-    //
-    //    }
+//
+//    if (!found) {
+//        printf("[%s] \?\?() \?\?:0\n",addr[naddr-1]);
+//    } else {
+//        const char *name;
+//
+//        name = functionname;
+//        if (name == NULL || *name == '\0')
+//            name = "??";
+//        if (filename != NULL) {
+//            char *h;
+//
+//            h = strrchr(filename, '/');
+//            if (h != NULL)
+//                filename = h + 1;
+//        }
+//
+//        printf("\t%s:%u\t", filename ? filename : "??",
+//               line);
+//
+//        printf("%s()\n", name);
+//
+//    }
 
 void printbt(item &item)
 {
@@ -107,7 +105,6 @@ void printbt(item &item)
 
     printf("Leak: %s type: %s address: %p\n", buf, "xxx", (void *) (&item));
     for (size_t i = 0; i < item.backtrace_size; i++) {
-
     }
     printf("\n");
     free(strings);
@@ -123,3 +120,4 @@ TEST_CASE("backtrace")
 
     mymapaddr();
 }
+}  // namespace test_backtrace

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -58,6 +58,11 @@ void a_calls_b(item &item)
 }
 }
 
+TEST_CASE("main2")
+{
+    main2();
+}
+
 
 TEST_CASE("qd_symbolize_backtrace_line")
 {

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -30,8 +30,8 @@ extern "C" {
 
 #include <cstdio>
 
-namespace test_backtrace
-{
+//namespace test_backtrace
+//{
 
 const int STACK_DEPTH = 10;
 
@@ -46,8 +46,7 @@ void b_stores_backtrace(item &item)
     item.backtrace_size = backtrace(item.backtrace, STACK_DEPTH);
 }
 
-void a_calls_b(item &item)
-{
+int a_calls_b_line = __LINE__; void __attribute__((noinline)) a_calls_b(item &item) {
     b_stores_backtrace(item);
 }
 }
@@ -70,8 +69,7 @@ bool found = false;
 
 void mymapaddr()
 {
-    const qd_backtrace_fileline_t &res = qd_symbolize_backtrace_line((bfd_vma) mymapaddr);
-    printf("found: %s %s %d", res.sourcefile, res.funcname, res.line);
+
 }
 
 //
@@ -110,14 +108,20 @@ void printbt(item &item)
     free(strings);
 }
 
-TEST_CASE("backtrace")
+TEST_CASE("qd_symbolize_backtrace_line")
 {
     item i;
-
     a_calls_b(i);
 
-    printbt(i);
+    const qd_backtrace_fileline_t &res = qd_symbolize_backtrace_line((bfd_vma) a_calls_b);
+    printf("found: %s %s %d", res.sourcefile, res.funcname, res.line);
+    REQUIRE(res.sourcefile == __FILE__);
+    REQUIRE(res.funcname == "a_calls_b");
+    REQUIRE(res.line == a_calls_b_line);
+    qd_symbolize_finalize();
 
-    mymapaddr();
+//    printbt(i);
+
+//    mymapaddr();
 }
-}  // namespace test_backtrace
+//}  // namespace test_backtrace

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -42,7 +42,7 @@ struct item {
 
 extern "C" {
 
-int probe_line = __LINE__ + 2;
+int probe_line = __LINE__;
 void probe()
 {
 }

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -62,7 +62,7 @@ void a_calls_b(item &item)
 TEST_CASE("qd_symbolize_backtrace_line")
 {
     const qd_backtrace_fileline_t &res = qd_symbolize_backtrace_line((bfd_vma) probe);
-    REQUIRE(res.found);
+    CHECK(res.found);
     if(!res.found) {
         qd_symbolize_finalize();
         return;


### PR DESCRIPTION
Test this by deliberately causing leaks, then start and stop router

```c
void qd_dealloc(qd_alloc_type_desc_t *desc, qd_alloc_pool_t **tpool, char *p)
{
    return;
```

This produces for me

```
Leak: 2022-04-15 19:03:59.018928 +0200 type: qd_log_entry_t address: 0x61d000090710
   /lib64/libasan.so.6(+0x44701) [0x7f4a4814a701]
#1 qd_alloc /home/jdanek/repos/skupper-router/src/alloc_pool.c:369
#2 qd_vlog_impl /home/jdanek/repos/skupper-router/src/log.c:64
#3 qd_log_impl /home/jdanek/repos/skupper-router/src/log.c:465
#4 qdr_modules_finalize /home/jdanek/repos/skupper-router/src/router_core/router_core_thread.c:149
#5 qdr_core_free /home/jdanek/repos/skupper-router/src/router_core/router_core.c:236
#6 qd_router_free /home/jdanek/repos/skupper-router/src/router_node.c:2096
#7 (??) /home/jdanek/repos/skupper-router/src/dispatch.c:359
#8 (??) /home/jdanek/repos/skupper-router/router/src/main.c:111
#9 main /home/jdanek/repos/skupper-router/router/src/main.c:359

alloc.c: Items of type 'qd_iterator_t' remain allocated at shutdown: 37 (SUPPRESSED)
alloc.c: Items of type 'qd_hash_item_t' remain allocated at shutdown: 15
Leak: 2022-04-15 19:03:57.773083 +0200 type: qd_hash_item_t address: 0x611000006c50
   /lib64/libasan.so.6(+0x44701) [0x7f4a4814a701]
#1 qd_alloc /home/jdanek/repos/skupper-router/src/alloc_pool.c:434
#2 (??) /home/jdanek/repos/skupper-router/src/hash.c:38
#3 qd_hash_insert /home/jdanek/repos/skupper-router/src/hash.c:222
#4 qd_container_register_node_type /home/jdanek/repos/skupper-router/src/container.c:821
#5 qd_router /home/jdanek/repos/skupper-router/src/router_node.c:1565
#6 qd_dispatch_prepare /home/jdanek/repos/skupper-router/src/dispatch.c:318
   /lib64/libffi.so.6(ffi_call_unix64+0x4c) [0x7f4a43a31c04]
   /lib64/libffi.so.6(ffi_call+0x1d8) [0x7f4a43a31108]
   /usr/lib64/python3.10/lib-dynload/_ctypes.cpython-310-x86_64-linux-gnu.so(+0x1224a) [0x7f4a43a6224a]
```

(full log in attachment: [339_skrouterd_symbolized_leaks.txt](https://github.com/skupperproject/skupper-router/files/8497115/339_skrouterd_symbolized_leaks.txt))

## TODO

* [ ] depend on `-lbfd` only when `QD_MEMORY_DEBUG` is defined
* [ ] add the linked libraries better, maybe `find_library`
* [ ] find out what I depend on, the slides on the issue say I need all of `-lbfd -liberty -ldl -lz`
* [ ] decide what to do if `binutils-devel` is not installed; I am inclined on making package mandatory when `QD_MEMORY_DEBUG` is set
* [ ] depend on static versions of libs if possible; this does not matter so much since this is not in production build
* [ ] finish the unittest for this; use the `a_calls_b` functions, ..., to get sample stacktrace, use `__LINE__` to check correct line; this will only work for debug and relwithdebinfo build (needs debug symbols)
* [ ] add some more error handling and reporting, to diagnose problems should they occur in the future