### PR TITLE
Use Fedora 36 in GitHub Actions CI builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -307,7 +307,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         container: ['fedora']
-        containerTag: ['35']
+        containerTag: ['36']
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
         protonGitRef:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -464,10 +464,12 @@ jobs:
       - name: Zero ccache stats
         run: ccache -z
 
+      # PROTON-2473: either install `openssl1.1-devel` compat version, or build with `-Wno-error=deprecated-declarations`
       - name: qpid-proton cmake configure
         working-directory: ${{env.ProtonBuildDir}}
         run: >
           cmake "${{github.workspace}}/qpid-proton" \
+            '-DCMAKE_C_FLAGS="-Wno-error=deprecated-declarations"' \
             "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" \
             "-DCMAKE_BUILD_TYPE=${BuildType}" \
             ${ProtonCMakeExtraArgs}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -348,7 +348,7 @@ jobs:
           # coverage
           - os: ubuntu-20.04
             container: 'fedora'
-            containerTag: 35
+            containerTag: 36
             buildType: Coverage
             runtimeCheck: OFF
             protonGitRef: 0.37.0
@@ -429,10 +429,6 @@ jobs:
         run: |
           dnf -y install epel-release
           dnf config-manager --set-enabled powertools
-
-      - name: Install dmesg on Fedora 35
-        if: ${{ matrix.container == 'fedora' }}
-        run: dnf install -y util-linux-core
 
       - name: Install Linux build dependencies
         run: |


### PR DESCRIPTION
* [x] Workaround [PROTON-2473: Deprecation warnings when compiling Proton with OpenSSL 3](https://issues.apache.org/jira/browse/PROTON-2473) 
* [x] currently fails due to https://github.com/skupperproject/skupper-router/issues/344
* [x] and https://github.com/skupperproject/skupper-router/issues/346
* [x] https://github.com/skupperproject/skupper-router/issues/636
* [x] https://github.com/skupperproject/skupper-router/issues/543