### PR TITLE
Fixes #375 - Enable IPv6 inside Docker container to run ip6 tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -311,7 +311,7 @@ jobs:
       image: 'quay.io/${{ matrix.container }}/${{ matrix.container }}:${{ matrix.containerTag }}'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
-      options: --privileged --ulimit core=-1 --security-opt apparmor:unconfined --security-opt seccomp=unconfined
+      options: --privileged --ulimit core=-1 --security-opt apparmor:unconfined --security-opt seccomp=unconfined --sysctl net.ipv6.conf.all.disable_ipv6=0
 
     env:
       BuildType: ${{matrix.buildType}}


### PR DESCRIPTION
The commenter on https://forums.docker.com/t/unable-to-add-ipv6-address-to-dummy-interface-inside-the-container/83321/2
who showed the way be praised with great praise!

All hail @dels78!