### PR TITLE
Issue #170 - Give pytest more screen width in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -191,6 +191,7 @@ jobs:
       QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST: True
       # this enables colored output
       FORCE_COLOR: 1
+      COLUMNS: 160
 
     steps:
 
@@ -321,6 +322,7 @@ jobs:
       RouterCTestExtraArgs: ""
       # this enables colored output
       FORCE_COLOR: 1
+      COLUMNS: 160
 
       # TODO(DISPATCH-2144) use -DPython_EXECUTABLE=/usr/bin/python3-debug when issue is fixed,
       #  as that allows for -DSANITIZE_3RD_PARTY=ON on Fedora
@@ -520,6 +522,7 @@ jobs:
         -GNinja
       # this enables colored output
       FORCE_COLOR: 1
+      COLUMNS: 160
 
     steps:
 


### PR DESCRIPTION
## Before

https://github.com/skupperproject/skupper-router/runs/6233696040?check_suite_focus=true#step:26:6262

```
=========================== short test summary info ============================
FAILED ::TcpAdaptor::test_70_half_closed - AssertionError: assert 0 > 0
FAILED ::TcpAdaptor::test_80_stats - Exception: ConnectionException: Connecti...
ERROR ::TcpAdaptor::test_80_stats - RuntimeError: Errors during teardown: 
========= 2 failed, 10 passed, 1 skipped, 1 error in 385.44s (0:06:25) =========
```

## After

https://github.com/jiridanek/skupper-router/runs/6239723615?check_suite_focus=true#step:9:6115

```
59: =================================================================== short test summary info ====================================================================
59: FAILED ::TcpAdaptor::test_70_half_closed - AssertionError: assert 0 > 0
59: FAILED ::TcpAdaptor::test_80_stats - Exception: ConnectionException: Connection amqp://0.0.0.0:22464 disconnected: Condition('proton.pythonio', 'Connection r...
59: ERROR ::TcpAdaptor::test_80_stats - RuntimeError: Errors during teardown: 
59: ================================================= 2 failed, 10 passed, 1 skipped, 1 error in 398.63s (0:06:38) =================================================
```