### PR TITLE
Issue #375 - Do not retry request on EADDRNOTAVAIL

### DIFF
--- a/tests/system_tests_http.py
+++ b/tests/system_tests_http.py
@@ -97,8 +97,7 @@ class RouterTestHttp(TestCase):
                 self.get(url, use_ca=use_ca)
             return False
         except OSError as e:
-            # EADDRNOTAVAIL happens in Docker when connecting to localhost:port where nobody listens
-            expected = (errno.ECONNREFUSED, errno.ECONNRESET, errno.EADDRNOTAVAIL)
+            expected = (errno.ECONNREFUSED, errno.ECONNRESET)
             if e.errno in expected or e.reason.errno in expected:
                 return True
             raise e


### PR DESCRIPTION
@astitcher I confess I forgot what this was about, but I do remember that retry upon EADDRNOTAVAIL is not the correct thing to do. Do you please remember what the Jenkins and Docker IPv6 problems were about and why this is the right thing to do?

Edit: there is actually Jira, [[CI/CD] Proton jobs failing with OSError: [Errno 99] Cannot assign requested address](https://issues.redhat.com/browse/ENTMQCL-3130), so we don't need astitcher's recollections, after all