### PR TITLE
Issue #260 - Avoid `DEQ_REMOVE_HEAD` to make list deletion in `qd_buffer_list_free_buffers` more efficient

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -86,11 +86,12 @@ unsigned int qd_buffer_list_clone(qd_buffer_list_t *dst, const qd_buffer_list_t 
 void qd_buffer_list_free_buffers(qd_buffer_list_t *list)
 {
     qd_buffer_t *buf = DEQ_HEAD(*list);
-    while (buf) {
-        DEQ_REMOVE_HEAD(*list);
+    while (buf != NULL) {
+        qd_buffer_t *next = DEQ_NEXT(buf);
         qd_buffer_free(buf);
-        buf = DEQ_HEAD(*list);
+        buf = next;
     }
+    DEQ_INIT(*list);
 }
 
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -86,7 +86,7 @@ unsigned int qd_buffer_list_clone(qd_buffer_list_t *dst, const qd_buffer_list_t 
 void qd_buffer_list_free_buffers(qd_buffer_list_t *list)
 {
     qd_buffer_t *buf = DEQ_HEAD(*list);
-    while (buf != NULL) {
+    while (buf) {
         qd_buffer_t *next = DEQ_NEXT(buf);
         qd_buffer_free(buf);
         buf = next;


### PR DESCRIPTION
See the issue for the asm diff. 

There are other places that use the inefficient deletion, but they did not show on the cpu profile. It is possible to create a macro for these deletions, with the function to call to free item as a macro parameter. Some list deletions perform a more complicated freeing, however, and there such macro is not sufficient.