### PR TITLE
Fixes #446 - Refactor `retry_exception` into less-forgiving general retry (of same name) and `retry_assertion` test helper function

### DIFF
--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -186,7 +186,7 @@ def retry_exception(
     while True:
         try:
             return function()
-        except exception as e:
+        except exception as e:  # pylint: disable=misc  # error: Exception type must be derived from BaseException
             if exception_test:
                 exception_test(e)
             delay = retry_delay(deadline, delay, max_delay)

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -186,7 +186,7 @@ def retry_exception(
     while True:
         try:
             return function()
-        except exception as e:  # pylint: disable=misc  # error: Exception type must be derived from BaseException
+        except exception as e:  # type: ignore[misc]  # Exception type must be derived from BaseException
             if exception_test:
                 exception_test(e)
             delay = retry_delay(deadline, delay, max_delay)

--- a/tests/system_tests_address_watch.py
+++ b/tests/system_tests_address_watch.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, unittest, TestTimeout, retry_exception
+from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, unittest, TestTimeout, retry_assertion
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from proton import Message
@@ -255,17 +255,17 @@ class AddressWatchTest(MessagingHandler):
                     search_lines = [s for s in log_lines if "ADDRESS_WATCH" in s and "on_watch(%d)" % self.index in s]
                     matches = [s for s in search_lines if "loc: 1 rem: 0" in s]
                     if len(matches) == 0:
-                        raise Exception("Didn't see local consumer on router 1")
+                        raise AssertionError("Didn't see local consumer on router 1")
                 with open(self.host_b.logfile_path, 'r') as router_log:
                     log_lines = router_log.read().split("\n")
                     search_lines = [s for s in log_lines if "ADDRESS_WATCH" in s and "on_watch(%d)" % self.index in s]
                     matches = [s for s in search_lines if ("loc: 0 rem: 1" in s) or ("loc: 1 rem: 0" in s)]
                     if len(matches) == 0:
-                        raise Exception("Didn't see remote consumer and local producer on router 2")
+                        raise AssertionError("Didn't see remote consumer and local producer on router 2")
 
             # Sometimes the CI is so fast that there is not enough time for the router to write to the log file.
             # Try repeatedly until TIMEOUT seconds.
-            retry_exception(check_log_lines, delay=2)
+            retry_assertion(check_log_lines, delay=2)
             self.timer.cancel()
 
     def run(self):

--- a/tests/system_tests_sasl_plain.py
+++ b/tests/system_tests_sasl_plain.py
@@ -20,7 +20,7 @@
 from time import sleep
 import os
 from subprocess import PIPE, Popen
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, retry_exception
+from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, retry_assertion
 from system_test import unittest, QdManager, Process
 from skupper_router.management.client import Node
 from proton import SASL
@@ -725,7 +725,7 @@ class RouterTestVerifyHostNameNo(RouterTestPlainSaslCommon):
         # Even though we deleted the connector, it might take a bit of time for the actual connection
         # object to be deleted since there might be some latency with the core thread. Retry the
         # connection query till TIMEOUT seconds.
-        retry_exception(check_connections)
+        retry_assertion(check_connections)
 
         # re-create the ssl profile
         local_node.create({'type': 'sslProfile',

--- a/tests/system_tests_skmanage.py
+++ b/tests/system_tests_skmanage.py
@@ -387,7 +387,7 @@ class SkmanageTest(TestCase):
 
         # The connector has been created, check to make sure that there is at least one
         # connection of role 'inter-router'
-        retry_assertion(query_inter_router_connector, delay=2, check_inter_router_present=True)
+        retry_assertion(lambda: query_inter_router_connector(check_inter_router_present=True), delay=2)
 
     def test_zzz_add_connector(self):
         port = self.get_port()

--- a/tests/system_tests_skmanage.py
+++ b/tests/system_tests_skmanage.py
@@ -28,7 +28,7 @@ from proton.utils import BlockingConnection
 from skupper_router_internal.compat import dictify
 from skupper_router_internal.management.qdrouter import QdSchema
 
-from system_test import unittest, retry_exception
+from system_test import unittest, retry_assertion
 from system_test import Logger, TestCase, Process, Qdrouterd, main_module, TIMEOUT, DIR
 from system_test import QdManager
 
@@ -190,7 +190,7 @@ class SkmanageTest(TestCase):
                 self.assertEqual(2, len(e))
             self.assertEqual(name_type(qall), name_type(qattr))
 
-        retry_exception(query_type_name)
+        retry_assertion(query_type_name)
 
     def test_get_schema(self):
         schema = dictify(QdSchema().dump())
@@ -370,7 +370,7 @@ class SkmanageTest(TestCase):
                 self.assertTrue(inter_router_present)
 
         # The connector has been deleted, check to make sure that there are no connections of 'inter-router' role
-        retry_exception(query_inter_router_connector, delay=2)
+        retry_assertion(query_inter_router_connector, delay=2)
 
         # Create back the connector with role="inter-router"
         self.create(long_type, name, str(SkmanageTest.inter_router_port), role="inter-router")
@@ -387,7 +387,7 @@ class SkmanageTest(TestCase):
 
         # The connector has been created, check to make sure that there is at least one
         # connection of role 'inter-router'
-        retry_exception(query_inter_router_connector, delay=2, check_inter_router_present=True)
+        retry_assertion(query_inter_router_connector, delay=2, check_inter_router_present=True)
 
     def test_zzz_add_connector(self):
         port = self.get_port()


### PR DESCRIPTION
The old `retry_exception` was too forgiving regarding `SyntaxError` and other such similar exceptions.
These should not trigger retry, as they are likely an unintentional programming error.

The case of retrying on `AssertionError` is now to be handled by `retry_assertion`.