### PR TITLE
Fixes #444 - Build the router container with production-like flags, such as the various flavors of `-fstack-protector` and with `-D_FORTIFY_SOURCE=2`

### DIFF
--- a/.github/scripts/compile.sh
+++ b/.github/scripts/compile.sh
@@ -98,7 +98,8 @@ do_build () {
 
 do_build "" OFF
 
-common_sanitizer_flags="-Wp,-U_FORTIFY_SOURCE -fplugin-arg-annobin-no-active-checks"
+# talking to annobin is not straightforward, https://bugzilla.redhat.com/show_bug.cgi?id=1536569
+common_sanitizer_flags="-Wp,-U_FORTIFY_SOURCE -fplugin=annobin -fplugin-arg-annobin-no-active-checks"
 export CFLAGS="${CFLAGS} ${common_sanitizer_flags}"
 export CXXFLAGS="${CXXFLAGS} ${common_sanitizer_flags}"
 do_build "_asan" asan

--- a/.github/scripts/compile.sh
+++ b/.github/scripts/compile.sh
@@ -97,6 +97,8 @@ do_build () {
 }
 
 do_build "" OFF
+# options that are needed for sanitizers do not pass annobin active checks
+eval "$(rpmbuild --undefine=_annotated_build --eval '%set_build_flags')"
 do_build "_asan" asan
 do_build "_tsan" tsan
 

--- a/.github/scripts/compile.sh
+++ b/.github/scripts/compile.sh
@@ -97,8 +97,10 @@ do_build () {
 }
 
 do_build "" OFF
-# options that are needed for sanitizers do not pass annobin active checks
-eval "$(rpmbuild --undefine=_annotated_build --eval '%set_build_flags')"
+
+common_sanitizer_flags="-Wp,-U_FORTIFY_SOURCE -fplugin-arg-annobin-no-active-checks"
+export CFLAGS="${CFLAGS} ${common_sanitizer_flags}"
+export CXXFLAGS="${CXXFLAGS} ${common_sanitizer_flags}"
 do_build "_asan" asan
 do_build "_tsan" tsan
 

--- a/.github/scripts/compile.sh
+++ b/.github/scripts/compile.sh
@@ -22,6 +22,7 @@
 set -euxo pipefail
 
 WORKING=$(pwd)
+eval "$(rpmbuild --eval '%set_build_flags')"
 
 #region libwebsockets
 wget ${LWS_SOURCE_URL} -O libwebsockets.tar.gz

--- a/Containerfile
+++ b/Containerfile
@@ -20,6 +20,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
 
 RUN microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
+    rpm-build \
     gcc gcc-c++ make cmake \
     cyrus-sasl-devel openssl-devel libuuid-devel \
     python3-devel swig \

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -147,7 +147,8 @@ elseif(RUNTIME_CHECK STREQUAL "asan" OR RUNTIME_CHECK STREQUAL "hwasan")
   add_custom_target(generate_lsan.supp ALL
         DEPENDS ${CMAKE_BINARY_DIR}/tests/lsan.supp)
   # force QD_MEMORY_DEBUG else lsan will catch alloc_pool suppressed leaks (ok to remove this once leaks are fixed)
-  set(SANITIZE_FLAGS "-g -fno-omit-frame-pointer -fsanitize=${ASAN_VARIANTS} -DQD_MEMORY_DEBUG=1")
+  # set -Wp,-U_FORTIFY_SOURCE to avoid bad interaction with fortify flags, https://developers.redhat.com/blog/2021/05/05/memory-error-checking-in-c-and-c-comparing-sanitizers-and-valgrind#fortifysource
+  set(SANITIZE_FLAGS "-g -fno-omit-frame-pointer -Wp,-U_FORTIFY_SOURCE -fsanitize=${ASAN_VARIANTS} -DQD_MEMORY_DEBUG=1")
   # `detect_leaks=1` is set by default where it is available; better not to set it conditionally ourselves
   # https://github.com/openSUSE/systemd/blob/1270e56526cd5a3f485ae2aba975345c38860d37/docs/TESTING_WITH_SANITIZERS.md
   # TODO(DISPATCH-2148) re-enable odr violation detection when Proton linking issue in test-sender is fixed
@@ -162,7 +163,7 @@ elseif(RUNTIME_CHECK STREQUAL "tsan")
     message(FATAL_ERROR "libtsan not installed - thread sanitizer not available")
   endif(TSAN_LIBRARY-NOTFOUND)
   message(STATUS "Runtime race checker: gcc/clang thread sanitizer")
-  set(SANITIZE_FLAGS "-g -fno-omit-frame-pointer -fsanitize=thread")
+  set(SANITIZE_FLAGS "-g -fno-omit-frame-pointer -Wp,-U_FORTIFY_SOURCE -fsanitize=thread")
   set(RUNTIME_TSAN_ENV_OPTIONS "disable_coredump=0 history_size=4 second_deadlock_stack=1 suppressions=${CMAKE_SOURCE_DIR}/tests/tsan.supp")
 
 elseif(RUNTIME_CHECK)

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -100,7 +100,7 @@ if(QD_DISABLE_MEMORY_POOL AND NOT RUNTIME_CHECK)
 endif()
 
 # set -Wp,-U_FORTIFY_SOURCE to avoid bad interaction with fortify flags, https://developers.redhat.com/blog/2021/05/05/memory-error-checking-in-c-and-c-comparing-sanitizers-and-valgrind#fortifysource
-set(common_sanitizer_flags -g -fno-omit-frame-pointer -Wp,-U_FORTIFY_SOURCE)
+set(common_sanitizer_flags "-g -fno-omit-frame-pointer -Wp,-U_FORTIFY_SOURCE")
 
 if(RUNTIME_CHECK STREQUAL "memcheck")
   assert_has_valgrind()

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -99,6 +99,9 @@ if(QD_DISABLE_MEMORY_POOL AND NOT RUNTIME_CHECK)
   message(FATAL_ERROR "Do not set QD_DISABLE_MEMORY_POOL without enabling RUNTIME_CHECK at the same time")
 endif()
 
+# set -Wp,-U_FORTIFY_SOURCE to avoid bad interaction with fortify flags, https://developers.redhat.com/blog/2021/05/05/memory-error-checking-in-c-and-c-comparing-sanitizers-and-valgrind#fortifysource
+set(common_sanitizer_flags -g -fno-omit-frame-pointer -Wp,-U_FORTIFY_SOURCE)
+
 if(RUNTIME_CHECK STREQUAL "memcheck")
   assert_has_valgrind()
   message(STATUS "Runtime memory checker: valgrind memcheck")
@@ -147,8 +150,7 @@ elseif(RUNTIME_CHECK STREQUAL "asan" OR RUNTIME_CHECK STREQUAL "hwasan")
   add_custom_target(generate_lsan.supp ALL
         DEPENDS ${CMAKE_BINARY_DIR}/tests/lsan.supp)
   # force QD_MEMORY_DEBUG else lsan will catch alloc_pool suppressed leaks (ok to remove this once leaks are fixed)
-  # set -Wp,-U_FORTIFY_SOURCE to avoid bad interaction with fortify flags, https://developers.redhat.com/blog/2021/05/05/memory-error-checking-in-c-and-c-comparing-sanitizers-and-valgrind#fortifysource
-  set(SANITIZE_FLAGS "-g -fno-omit-frame-pointer -Wp,-U_FORTIFY_SOURCE -fsanitize=${ASAN_VARIANTS} -DQD_MEMORY_DEBUG=1")
+  set(SANITIZE_FLAGS "${common_sanitizer_flags} -fsanitize=${ASAN_VARIANTS} -DQD_MEMORY_DEBUG=1")
   # `detect_leaks=1` is set by default where it is available; better not to set it conditionally ourselves
   # https://github.com/openSUSE/systemd/blob/1270e56526cd5a3f485ae2aba975345c38860d37/docs/TESTING_WITH_SANITIZERS.md
   # TODO(DISPATCH-2148) re-enable odr violation detection when Proton linking issue in test-sender is fixed
@@ -163,7 +165,7 @@ elseif(RUNTIME_CHECK STREQUAL "tsan")
     message(FATAL_ERROR "libtsan not installed - thread sanitizer not available")
   endif(TSAN_LIBRARY-NOTFOUND)
   message(STATUS "Runtime race checker: gcc/clang thread sanitizer")
-  set(SANITIZE_FLAGS "-g -fno-omit-frame-pointer -Wp,-U_FORTIFY_SOURCE -fsanitize=thread")
+  set(SANITIZE_FLAGS "${common_sanitizer_flags} -fsanitize=thread")
   set(RUNTIME_TSAN_ENV_OPTIONS "disable_coredump=0 history_size=4 second_deadlock_stack=1 suppressions=${CMAKE_SOURCE_DIR}/tests/tsan.supp")
 
 elseif(RUNTIME_CHECK)


### PR DESCRIPTION
## Before
https://github.com/skupperproject/skupper-router/runs/6320497602?check_suite_focus=true#step:3:1453
> [  8%] Building C object c/CMakeFiles/qpid-proton-proactor-objects.dir/src/proactor/netaddr-internal.c.o
cd /build/proton_build/c && /usr/bin/cc -Dqpid_proton_proactor_EXPORTS -I/build/qpid-proton-src/c/include -I/build/qpid-proton-src/c/src -I/build/proton_build/c/include -I/build/proton_build/c/src -fvisibility=hidden -O2 -g -DNDEBUG -flto -fno-fat-lto-objects -fPIC -flto -fno-fat-lto-objects -std=c99 -Werror -Wall -pedantic-errors -Wno-unused-parameter -Wstrict-prototypes -Wvla -Wsign-compare -Wwrite-strings  -MD -MT c/CMakeFiles/qpid-proton-proactor-objects.dir/src/proactor/netaddr-internal.c.o -MF CMakeFiles/qpid-proton-proactor-objects.dir/src/proactor/netaddr-internal.c.o.d -o CMakeFiles/qpid-proton-proactor-objects.dir/src/proactor/netaddr-internal.c.o -c /build/qpid-proton-src/c/src/proactor/netaddr-internal.c

## After
https://github.com/jiridanek/skupper-router/runs/6325383502?check_suite_focus=true#step:3:1533
> [  8%] Building C object c/CMakeFiles/qpid-proton-proactor-objects.dir/src/proactor/netaddr-internal.c.o
cd /build/proton_build/c && /usr/bin/cc -Dqpid_proton_proactor_EXPORTS -I/build/qpid-proton-src/c/include -I/build/qpid-proton-src/c/src -I/build/proton_build/c/include -I/build/proton_build/c/src -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fvisibility=hidden -O2 -g -DNDEBUG -flto -fno-fat-lto-objects -fPIC -flto -fno-fat-lto-objects -std=c99 -Werror -Wall -pedantic-errors -Wno-unused-parameter -Wstrict-prototypes -Wvla -Wsign-compare -Wwrite-strings  -MD -MT c/CMakeFiles/qpid-proton-proactor-objects.dir/src/proactor/netaddr-internal.c.o -MF CMakeFiles/qpid-proton-proactor-objects.dir/src/proactor/netaddr-internal.c.o.d -o CMakeFiles/qpid-proton-proactor-objects.dir/src/proactor/netaddr-internal.c.o -c /build/qpid-proton-src/c/src/proactor/netaddr-internal.c

The question is, whether it is acceptable practice to set CFLAGS this way?