### PR TITLE
Fixes #440: Replace distutils with setuptools

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-set -Eeuo pipefail
-
 if [[ ! -f config.sh ]]; then
     echo "You must source config.sh from within its own directory"
     return
@@ -31,5 +29,5 @@ export INSTALL_DIR=$SOURCE_DIR/${2:-install}
 PYTHON_BIN=$(command -v python3 || command -v python)
 PYTHON_LIB=$(${PYTHON_BIN} -c "from sysconfig import get_path; print(get_path(name='purelib', vars={'base': '$INSTALL_DIR'}))")
 
-export PYTHONPATH=$PYTHON_LIB:$PYTHONPATH
+export PYTHONPATH=$PYTHON_LIB:${PYTHONPATH:-}
 export PATH=$INSTALL_DIR/sbin:$INSTALL_DIR/bin:$SOURCE_DIR/bin:$PATH

--- a/config.sh
+++ b/config.sh
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+set -Eeuo pipefail
+
 if [[ ! -f config.sh ]]; then
     echo "You must source config.sh from within its own directory"
     return
@@ -26,8 +28,8 @@ export SOURCE_DIR=$(pwd)
 export BUILD_DIR=$SOURCE_DIR/${1:-build}
 export INSTALL_DIR=$SOURCE_DIR/${2:-install}
 
-PYTHON_BIN=`type -P python || type -P python3`
-PYTHON_LIB=$(${PYTHON_BIN} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix='$INSTALL_DIR'))")
+PYTHON_BIN=$(command -v python3 || command -v python)
+PYTHON_LIB=$(${PYTHON_BIN} -c "from sysconfig import get_path; print(get_path(name='purelib', vars={'base': '$INSTALL_DIR'}))")
 
 export PYTHONPATH=$PYTHON_LIB:$PYTHONPATH
 export PATH=$INSTALL_DIR/sbin:$INSTALL_DIR/bin:$SOURCE_DIR/bin:$PATH

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -18,9 +18,9 @@
 # under the License.
 #
 
-from distutils.core import setup
-from distutils.command.build_py import build_py
-from distutils.file_util import copy_file
+from setuptools import setup
+from setuptools.command.build_py import build_py
+from setuptools.command.build_ext import copy_file
 from os.path import join
 from os import environ
 

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -25,8 +25,9 @@ import ssl
 import sys
 import re
 import time
-from pkg_resources import parse_version
 from subprocess import Popen, PIPE
+
+from pkg_resources import parse_version
 
 import cproton
 import proton

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -25,7 +25,7 @@ import ssl
 import sys
 import re
 import time
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 from subprocess import Popen, PIPE
 
 import cproton
@@ -125,7 +125,7 @@ class RouterTestSslClient(RouterTestSslBase):
             m = re.search(r'[0-9]+\.[0-9]+\.[0-9]+', openssl_out)
             assert m is not None
             OPENSSL_OUT_VER = m.group(0)
-            OPENSSL_VER_1_1_GT = StrictVersion(OPENSSL_OUT_VER) >= StrictVersion('1.1')
+            OPENSSL_VER_1_1_GT = parse_version(OPENSSL_OUT_VER) >= parse_version('1.1')
             print("OpenSSL Version found = %s" % OPENSSL_OUT_VER)
         except:
             pass

--- a/tests/tox.ini.in
+++ b/tests/tox.ini.in
@@ -281,3 +281,6 @@ ignore_missing_imports = True
 
 [mypy-pytest]
 ignore_missing_imports = True
+
+[mypy-pkg_resources]
+ignore_missing_imports = True


### PR DESCRIPTION
This is straightforward replacement of one package with another. It does not give any thought to getting rid of the CMake preprocessing (`.py.in` files`) or to the ideas behind installing Python code into site-packages in the first place.

I am certainly open to looking into those and maybe doing something about it, instead of just replacing one package with another in response to a deprecation warning.

The top level config.sh and build.sh should be replaced too, with some kind of "project orchestration tool", maybe just a Makefile?