### PR TITLE
Fixes #412, DISPATCH-1962 - Python IoAdaptor shutdown leak

### DIFF
--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -324,6 +324,7 @@ qd_error_t qd_dispatch_prepare(qd_dispatch_t *qd)
 void qd_dispatch_set_agent(qd_dispatch_t *qd, void *agent) {
     assert(agent);
     assert(!qd->agent);
+    Py_IncRef(agent);
     qd->agent = agent;
 }
 

--- a/src/python_embedded.c
+++ b/src/python_embedded.c
@@ -66,6 +66,7 @@ void qd_python_finalize(void)
 {
     (void) qd_python_lock();
 
+    Py_DECREF(message_type);
     Py_DECREF(dispatch_module);
     dispatch_module = 0;
     PyGC_Collect();
@@ -565,7 +566,8 @@ static PyTypeObject LogAdapterType = {
     .tp_dealloc   = (destructor)LogAdapter_dealloc,
     .tp_flags     = Py_TPFLAGS_DEFAULT,
     .tp_methods   = LogAdapter_methods,
-    .tp_init      = (initproc)LogAdapter_init
+    .tp_init      = (initproc)LogAdapter_init,
+    .tp_new       = PyType_GenericNew,
 };
 
 
@@ -710,10 +712,24 @@ static int IoAdapter_init(IoAdapter *self, PyObject *args, PyObject *kwds)
     return 0;
 }
 
+// visit all members which may conceivably participate in reference cycles
+static int IoAdapter_traverse(IoAdapter* self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->handler);
+    return 0;
+}
+
+static int IoAdapter_clear(IoAdapter* self)
+{
+    Py_CLEAR(self->handler);
+    return 0;
+}
+
 static void IoAdapter_dealloc(IoAdapter* self)
 {
     qdr_core_unsubscribe(self->sub);
-    Py_DECREF(self->handler);
+    PyObject_GC_UnTrack(self);
+    IoAdapter_clear(self);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -795,10 +811,13 @@ static PyTypeObject IoAdapterType = {
     .tp_name      = DISPATCH_MODULE ".IoAdapter",
     .tp_doc       = "Dispatch IO Adapter",
     .tp_basicsize = sizeof(IoAdapter),
+    .tp_traverse  = (traverseproc)IoAdapter_traverse,
+    .tp_clear     = (inquiry)IoAdapter_clear,
     .tp_dealloc   = (destructor)IoAdapter_dealloc,
-    .tp_flags     = Py_TPFLAGS_DEFAULT,
+    .tp_flags     = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_methods   = IoAdapter_methods,
     .tp_init      = (initproc)IoAdapter_init,
+    .tp_new       = PyType_GenericNew,
 };
 
 
@@ -814,8 +833,6 @@ static void qd_register_constant(PyObject *module, const char *name, uint32_t va
 
 static void qd_python_setup(void)
 {
-    LogAdapterType.tp_new = PyType_GenericNew;
-    IoAdapterType.tp_new  = PyType_GenericNew;
     if ((PyType_Ready(&LogAdapterType) < 0) || (PyType_Ready(&IoAdapterType) < 0)) {
         qd_error_py();
         qd_log(log_source, QD_LOG_CRITICAL, "Unable to initialize Adapters");

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -2092,12 +2092,12 @@ void qd_router_free(qd_router_t *router)
 
     qd_container_set_default_node_type(router->qd, 0, 0, QD_DIST_BOTH);
 
+    qd_router_python_free(router);
     qdr_core_free(router->router_core);
     qd_tracemask_free(router->tracemask);
     qd_timer_free(router->timer);
     sys_mutex_free(router->lock);
     qd_router_configure_free(router);
-    qd_router_python_free(router);
 
     free(router);
     qd_router_id_finalize();

--- a/src/router_pynode.c
+++ b/src/router_pynode.c
@@ -443,6 +443,7 @@ qd_error_t qd_router_python_setup(qd_router_t *router)
     // Instantiate the router
     //
     pyRouter = PyObject_CallObject(pClass, pArgs);
+    Py_DECREF(pClass);
     Py_DECREF(pArgs);
     Py_DECREF(adapterType);
     QD_ERROR_PY_RET();
@@ -455,7 +456,14 @@ qd_error_t qd_router_python_setup(qd_router_t *router)
 }
 
 void qd_router_python_free(qd_router_t *router) {
-    // empty
+    qd_python_lock_state_t ls = qd_python_lock();
+    Py_XDECREF(pyRouter);
+    Py_CLEAR(pyTick);
+    Py_CLEAR(pySetMobileSeq);
+    Py_CLEAR(pySetMyMobileSeq);
+    Py_CLEAR(pyLinkLost);
+    PyGC_Collect();
+    qd_python_unlock(ls);
 }
 
 

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -3,9 +3,6 @@
 #
 
 # to be triaged; pretty much all tests
-leak:^IoAdapter_init$
-
-# to be triaged; pretty much all tests
 leak:^load_server_config$
 
 # to be triaged; system_tests_one_router, system_tests_policy


### PR DESCRIPTION
This is extracted from the previous Python leak PR as a minimal self-contained piece of work that can be reviewed and merged independently, first. It only has the IoAdaptor part without any PyCapsule part.

* https://github.com/skupperproject/skupper-router/pull/413