### PR TITLE
Add test for a static function `normalize_memory_size` in server.c

### DIFF
--- a/tests/c_unittests/CMakeLists.txt
+++ b/tests/c_unittests/CMakeLists.txt
@@ -28,6 +28,10 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZE_FLAGS}")
 endif()
 
+add_library(static_accessors_server_c SHARED
+        static_accessors_server_c.c)
+target_compile_options(static_accessors_server_c PRIVATE -fvisibility=hidden)
+
 add_executable(c_unittests
         qdr_stubbing_probe.cpp
         c_unittests_main.cpp
@@ -39,8 +43,9 @@ add_executable(c_unittests
         test_connection_manager_static.cpp
         test_listener_startup.cpp
         test_router_startup.cpp
+        test_server.cpp
         test_terminus.cpp)
-target_link_libraries(c_unittests cpp-stub pthread skupper-router)
+target_link_libraries(c_unittests cpp-stub pthread skupper-router static_accessors_server_c)
 
 file(COPY
         ${CMAKE_CURRENT_SOURCE_DIR}/minimal_silent.conf

--- a/tests/c_unittests/static_accessors_server_c.c
+++ b/tests/c_unittests/static_accessors_server_c.c
@@ -1,0 +1,8 @@
+#include "../../src/server.c"
+
+#include <stdint.h>
+
+__attribute__((visibility("default"))) double testonly_normalize_memory_size(const uint64_t bytes, const char **suffix)
+{
+    return normalize_memory_size(bytes, suffix);
+}

--- a/tests/c_unittests/test_server.cpp
+++ b/tests/c_unittests/test_server.cpp
@@ -1,0 +1,30 @@
+#include "cpp_stub.h"
+#include "qdr_doctest.hpp"
+// helpers.hpp goes after qdr_doctest.hpp
+#include "helpers.hpp"
+
+#include <stdint.h>
+
+extern "C" {
+double testonly_normalize_memory_size(const uint64_t bytes, const char **suffix);
+}
+
+static void test_normalize_memory_size(uint64_t bytes, double expected_value, const char *expected_suffix)
+{
+    const char *suffix = NULL;
+    double value       = testonly_normalize_memory_size(bytes, &suffix);
+    CHECK(value == expected_value);
+    CHECK(suffix == expected_suffix);
+}
+
+TEST_CASE("normalize_memory_size")
+{
+    test_normalize_memory_size(0, 0.0, "B");
+    test_normalize_memory_size(1023, 1023.0, "B");
+    test_normalize_memory_size(1024, 1.0, "KiB");
+    test_normalize_memory_size(1024 + 1024 / 2, 1.5, "KiB");
+    test_normalize_memory_size(1024 * 1024, 1.0, "MiB");
+    test_normalize_memory_size(1024 * 1024 * 1024, 1.0, "GiB");
+    test_normalize_memory_size(1024ul * 1024 * 1024 * 1024, 1.0, "TiB");
+    test_normalize_memory_size(UINT64_MAX, 16384.0, "TiB");
+}


### PR DESCRIPTION
The only way to gain access to a function declared static is either
- write the test in the same file (translation unit), which doctest encourages (see its README.md)
- include the `server.c` file into the test source

The first cannot be done because tests are in C++ and rest of code is in C.
The second does not work either, because the C code does not compile as C++ without small modifications, which however look weird (to a C programmer) and therefore are unacceptably intrusive

Therefore, behold an intermediate layer, a C shared library which re-exports (only) what needs to be visible in tests.
Thanks to careful work with symbol visibility, there can be one shared library combining all the files containing tested static methods, if more tests are added in the future.