### PR TITLE
Add option to run Skupper Router CI with any provided custom qpid-proton branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -291,7 +291,9 @@ jobs:
         containerTag: ['35']
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
-        protonGitRef: [${{ inputs.protonBranch }}, 0.37.0]
+        protonGitRef:
+          - ${{ github.event.inputs.protonBranch }}
+          - 0.37.0
         shard: [ 1, 2 ]
         shards: [ 2 ]
         include:
@@ -300,14 +302,14 @@ jobs:
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: ${{ inputs.protonBranch }}
+            protonGitRef: ${{ github.event.inputs.protonBranch }}
             shard: 1
             shards: 2
           - os: ubuntu-20.04
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: ${{ inputs.protonBranch }}
+            protonGitRef: ${{ github.event.inputs.protonBranch }}
             shard: 2
             shards: 2
           - os: ubuntu-20.04
@@ -388,7 +390,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ inputs.protonRepository }}
+          repository: ${{ github.event.inputs.protonRepository }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -571,8 +573,8 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ inputs.protonRepository }}
-          ref: ${{ inputs.protonBranch }}
+          repository: ${{ github.event.inputs.protonRepository }}
+          ref: ${{ github.event.inputs.protonBranch }}
           path: 'qpid-proton'
 
       - name: Install Linux build dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,8 +36,8 @@ on:
         required: false
 
 env:
-  protonRepository: "${{ env.protonRepository || 'apache/qpid-proton' }}"
-  protonBranch: "${{ env.protonBranch || 'main' }}"
+  protonRepository: "${{ github.event.inputs.protonRepository || 'apache/qpid-proton' }}"
+  protonBranch: "${{ github.event.inputs.protonBranch || 'main' }}"
 
 jobs:
   compile:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         os: [ubuntu-20.04]
         buildType: [Debug]
         runtimeCheck: [asan]
-        protonGitRef: [${{ inputs.protonBranch }}, 0.37.0]
+        protonGitRef: [${{ github.event.inputs.protonBranch || 'main' }}, 0.37.0]
     env:
       BuildType: ${{matrix.buildType}}
       ProtonBuildDir: ${{github.workspace}}/qpid-proton/build
@@ -85,7 +85,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ inputs.protonRepository }}
+          repository: ${{ github.event.inputs.protonRepository || 'apache/qpid-proton' }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,9 @@ jobs:
         os: [ubuntu-20.04]
         buildType: [Debug]
         runtimeCheck: [asan]
-        protonGitRef: [baf, 0.37.0]
+        protonGitRef:
+          - ${{ github.event.inputs.protonBranch || 'main' }}
+          - 0.37.0
     env:
       BuildType: ${{matrix.buildType}}
       ProtonBuildDir: ${{github.workspace}}/qpid-proton/build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         os: [ubuntu-20.04]
         buildType: [Debug]
         runtimeCheck: [asan]
-        protonGitRef: [${{ github.event.inputs.protonBranch || 'main' }}, 0.37.0]
+        protonGitRef: [baf, 0.37.0]
     env:
       BuildType: ${{matrix.buildType}}
       ProtonBuildDir: ${{github.workspace}}/qpid-proton/build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -192,7 +192,9 @@ jobs:
         os: [ubuntu-20.04]
         buildType: [Debug]
         runtimeCheck: [asan]
-        protonGitRef: [ ${{inputs.protonBranch }}, 0.37.0]
+        protonGitRef:
+          - ${{github.event.inputs.protonBranch || 'apache/qpid-proton' }}
+          - 0.37.0
         shard: [1, 2]
         shards: [2]
     env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,7 @@ on:
         default: main
         required: false
 
+# known limitation https://github.com/actions/runner/issues/480
 env:
   protonRepository: "${{ github.event.inputs.protonRepository || 'apache/qpid-proton' }}"
   protonBranch: "${{ github.event.inputs.protonBranch || 'main' }}"
@@ -50,7 +51,7 @@ jobs:
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
-          - ${{ env.protonBranch }}
+          - ${{ github.event.inputs.protonBranch || 'main' }}
           - 0.37.0
     env:
       BuildType: ${{matrix.buildType}}
@@ -197,7 +198,7 @@ jobs:
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
-          - ${{ env.protonBranch }}
+          - ${{ github.event.inputs.protonBranch || 'main' }}
           - 0.37.0
         shard: [1, 2]
         shards: [2]
@@ -296,7 +297,7 @@ jobs:
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
         protonGitRef:
-          - ${{ env.protonBranch }}
+          - ${{ github.event.inputs.protonBranch || 'main' }}
           - 0.37.0
         shard: [ 1, 2 ]
         shards: [ 2 ]
@@ -306,14 +307,14 @@ jobs:
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: ${{ env.protonBranch }}
+            protonGitRef: ${{ github.event.inputs.protonBranch || 'main' }}
             shard: 1
             shards: 2
           - os: ubuntu-20.04
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: ${{ env.protonBranch }}
+            protonGitRef: ${{ github.event.inputs.protonBranch || 'main' }}
             shard: 2
             shards: 2
           - os: ubuntu-20.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,8 +36,8 @@ on:
         required: false
 
 env:
-  protonRepository: "${{ github.env.protonRepository || 'apache/qpid-proton' }}"
-  protonBranch: "${{ github.env.protonBranch || 'main' }}"
+  protonRepository: "${{ env.protonRepository || 'apache/qpid-proton' }}"
+  protonBranch: "${{ env.protonBranch || 'main' }}"
 
 jobs:
   compile:
@@ -50,7 +50,7 @@ jobs:
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
-          - ${{ github.env.protonBranch }}
+          - ${{ env.protonBranch }}
           - 0.37.0
     env:
       BuildType: ${{matrix.buildType}}
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.env.protonRepository }}
+          repository: ${{ env.protonRepository }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -197,7 +197,7 @@ jobs:
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
-          - ${{ github.env.protonBranch }}
+          - ${{ env.protonBranch }}
           - 0.37.0
         shard: [1, 2]
         shards: [2]
@@ -296,7 +296,7 @@ jobs:
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
         protonGitRef:
-          - ${{ github.env.protonBranch }}
+          - ${{ env.protonBranch }}
           - 0.37.0
         shard: [ 1, 2 ]
         shards: [ 2 ]
@@ -306,14 +306,14 @@ jobs:
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: ${{ github.env.protonBranch }}
+            protonGitRef: ${{ env.protonBranch }}
             shard: 1
             shards: 2
           - os: ubuntu-20.04
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: ${{ github.env.protonBranch }}
+            protonGitRef: ${{ env.protonBranch }}
             shard: 2
             shards: 2
           - os: ubuntu-20.04
@@ -394,7 +394,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.env.protonRepository }}
+          repository: ${{ env.protonRepository }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -577,8 +577,8 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.env.protonRepository }}
-          ref: ${{ github.env.protonBranch }}
+          repository: ${{ env.protonRepository }}
+          ref: ${{ env.protonBranch }}
           path: 'qpid-proton'
 
       - name: Install Linux build dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
-          - ${{ github.event.inputs.protonBranch || 'main' }}
+          - ${{ github.event.inputs.protonBranch }}
           - 0.37.0
     env:
       BuildType: ${{matrix.buildType}}
@@ -193,7 +193,7 @@ jobs:
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
-          - ${{ github.event.inputs.protonBranch || 'apache/qpid-proton' }}
+          - ${{ github.event.inputs.protonBranch }}
           - 0.37.0
         shard: [1, 2]
         shards: [2]
@@ -390,7 +390,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.inputs.protonRepository }}
+          repository: ${{ github.event.inputs.protonRepository || 'apache/qpid-proton' }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -573,7 +573,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.inputs.protonRepository }}
+          repository: ${{ github.event.inputs.protonRepository || 'apache/qpid-proton' }}
           ref: ${{ github.event.inputs.protonBranch }}
           path: 'qpid-proton'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,21 @@
 
 name: Build
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      protonRepository:
+        description: GitHub repository where to fetch Qpid Proton from
+        type: string
+        default: apache/qpid-proton
+        required: false
+      protonBranch:
+        description: Branch in the protonRepository to check out (in addition to hardcoded branches)
+        type: string
+        default: main
+        required: false
 
 jobs:
   compile:
@@ -31,7 +45,7 @@ jobs:
         os: [ubuntu-20.04]
         buildType: [Debug]
         runtimeCheck: [asan]
-        protonGitRef: [main, 0.37.0]
+        protonGitRef: [${{ inputs.protonBranch }}, 0.37.0]
     env:
       BuildType: ${{matrix.buildType}}
       ProtonBuildDir: ${{github.workspace}}/qpid-proton/build
@@ -71,7 +85,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: 'apache/qpid-proton'
+          repository: ${{ inputs.protonRepository }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -176,7 +190,7 @@ jobs:
         os: [ubuntu-20.04]
         buildType: [Debug]
         runtimeCheck: [asan]
-        protonGitRef: [main, 0.37.0]
+        protonGitRef: [ ${{inputs.protonBranch }}, 0.37.0]
         shard: [1, 2]
         shards: [2]
     env:
@@ -273,7 +287,7 @@ jobs:
         containerTag: ['35']
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
-        protonGitRef: [main, 0.37.0]
+        protonGitRef: [${{ inputs.protonBranch }}, 0.37.0]
         shard: [ 1, 2 ]
         shards: [ 2 ]
         include:
@@ -282,14 +296,14 @@ jobs:
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: main
+            protonGitRef: ${{ inputs.protonBranch }}
             shard: 1
             shards: 2
           - os: ubuntu-20.04
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: main
+            protonGitRef: ${{ inputs.protonBranch }}
             shard: 2
             shards: 2
           - os: ubuntu-20.04
@@ -370,7 +384,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: 'apache/qpid-proton'
+          repository: ${{ inputs.protonRepository }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -553,8 +567,8 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: 'apache/qpid-proton'
-          ref: main
+          repository: ${{ inputs.protonRepository }}
+          ref: ${{ inputs.protonBranch }}
           path: 'qpid-proton'
 
       - name: Install Linux build dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,10 @@ on:
         default: main
         required: false
 
+env:
+  protonRepository: "${{ github.env.protonRepository || 'apache/qpid-proton' }}"
+  protonBranch: "${{ github.env.protonBranch || 'main' }}"
+
 jobs:
   compile:
     name: "Compile (${{matrix.os}}, ${{matrix.runtimeCheck}}, proton ${{matrix.protonGitRef}})"
@@ -46,7 +50,7 @@ jobs:
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
-          - ${{ github.event.inputs.protonBranch }}
+          - ${{ github.env.protonBranch }}
           - 0.37.0
     env:
       BuildType: ${{matrix.buildType}}
@@ -87,7 +91,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.inputs.protonRepository }}
+          repository: ${{ github.env.protonRepository }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -193,7 +197,7 @@ jobs:
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
-          - ${{ github.event.inputs.protonBranch }}
+          - ${{ github.env.protonBranch }}
           - 0.37.0
         shard: [1, 2]
         shards: [2]
@@ -292,7 +296,7 @@ jobs:
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
         protonGitRef:
-          - ${{ github.event.inputs.protonBranch }}
+          - ${{ github.env.protonBranch }}
           - 0.37.0
         shard: [ 1, 2 ]
         shards: [ 2 ]
@@ -302,14 +306,14 @@ jobs:
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: ${{ github.event.inputs.protonBranch }}
+            protonGitRef: ${{ github.env.protonBranch }}
             shard: 1
             shards: 2
           - os: ubuntu-20.04
             container: 'centos'
             containerTag: stream8
             runtimeCheck: OFF
-            protonGitRef: ${{ github.event.inputs.protonBranch }}
+            protonGitRef: ${{ github.env.protonBranch }}
             shard: 2
             shards: 2
           - os: ubuntu-20.04
@@ -390,7 +394,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.inputs.protonRepository }}
+          repository: ${{ github.env.protonRepository }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -573,8 +577,8 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.inputs.protonRepository }}
-          ref: ${{ github.event.inputs.protonBranch }}
+          repository: ${{ github.env.protonRepository }}
+          ref: ${{ github.env.protonBranch }}
           path: 'qpid-proton'
 
       - name: Install Linux build dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.inputs.protonRepository || 'apache/qpid-proton' }}
+          repository: ${{ github.event.inputs.protonRepository }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -390,7 +390,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.inputs.protonRepository || 'apache/qpid-proton' }}
+          repository: ${{ github.event.inputs.protonRepository }}
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
@@ -573,7 +573,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.inputs.protonRepository || 'apache/qpid-proton' }}
+          repository: ${{ github.event.inputs.protonRepository }}
           ref: ${{ github.event.inputs.protonBranch }}
           path: 'qpid-proton'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ on:
       protonRepository:
         description: GitHub repository where to fetch Qpid Proton from
         type: string
-        default: apache/qpid-proton
+        default: 'apache/qpid-proton'
         required: false
       protonBranch:
         description: Branch in the protonRepository to check out (in addition to hardcoded branches)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -193,7 +193,7 @@ jobs:
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
-          - ${{github.event.inputs.protonBranch || 'apache/qpid-proton' }}
+          - ${{ github.event.inputs.protonBranch || 'apache/qpid-proton' }}
           - 0.37.0
         shard: [1, 2]
         shards: [2]


### PR DESCRIPTION
Select the "Build" workflow, click "Run workflow", type your username and branch you want to test with to the drop form. Confirm that, and things start happening.

![image](https://user-images.githubusercontent.com/442720/169088327-a6a6e6ef-0b88-40f5-a96e-9dcc0229b555.png)

Here are results, https://github.com/jiridanek/skupper-router/runs/6492730363?check_suite_focus=true