### PR TITLE
Fixes #452: fix python linter errors

### DIFF
--- a/python/skupper_router_internal/dispatch.py
+++ b/python/skupper_router_internal/dispatch.py
@@ -40,7 +40,7 @@ import sys
 from ctypes import c_char_p, c_long, py_object, c_void_p, c_bool, PyDLL
 from types import ModuleType
 
-from typing import List, Callable, TYPE_CHECKING, Optional
+from typing import List, Callable, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .router.message import Message
@@ -76,8 +76,7 @@ class IoAdapter:
     def __init__(self, handler: Callable, address: str, aclass: str, treatment: int) -> None:
         ...
 
-    def send(self, message: 'Message', no_echo: Optional[bool] = True, control:
-             Optional[bool] = False) -> None:
+    def send(self, message: 'Message', no_echo: bool = True, control: bool = False) -> None:
         ...
 
 

--- a/src/python_embedded.c
+++ b/src/python_embedded.c
@@ -771,7 +771,7 @@ static PyObject *qd_python_send(PyObject *self, PyObject *args)
     int       no_echo = 1;
     int       control = 0;
 
-    if (!PyArg_ParseTuple(args, "O|ii", &message, &no_echo, &control))
+    if (!PyArg_ParseTuple(args, "O|pp", &message, &no_echo, &control))
         return 0;
 
     if (compose_python_message(&field, message, ioa->qd) == QD_ERROR_NONE) {


### PR DESCRIPTION
The previous commit to fix #452 introduced linter errors on Fedora 34.  This patch fixes those errors.