### PR TITLE
Fixes #485 - Add `--single-version-externally-managed` to setup.py command line, 'cause it seems to help

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,7 +27,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/skupper_router_site.py.in
                ${CMAKE_CURRENT_BINARY_DIR}/skupper_router_site.py)
 
 # Install script for public python modules
-install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} setup.py -v install --single-version-externally-managed --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
+install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} setup.py -v install --single-version-externally-managed --record=/dev/null --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
 
 install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/skupper_router/management/skrouter.json

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,7 +27,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/skupper_router_site.py.in
                ${CMAKE_CURRENT_BINARY_DIR}/skupper_router_site.py)
 
 # Install script for public python modules
-install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} setup.py -v install --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
+install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} setup.py -v install --single-version-externally-managed --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
 
 install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/skupper_router/management/skrouter.json

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -60,5 +60,7 @@ setup(
     author='Skupper Project',
     author_email='skupper@googlegroups.com',
     url='https://skupper.io/',
-    license='Apache Software License'
+    license='Apache Software License',
+
+    zip_safe=False,
 )


### PR DESCRIPTION
There is some magic. When installing to system `site_packages`, things just work. When installing to these other custom locations, things do not work.

Can you try this change, it is a small one, it worked for me?

My installs were broken even after I reverted https://github.com/skupperproject/skupper-router/issues/440. Either I was reverting wrong, or this thing is just broken, regardless whether setuptools or distutils is imported in setup.py

I was reading about the .pth files, and all the .egg-info stuff and so on. Did not help me to make sense out of it. https://setuptools.pypa.io/en/latest/deprecated/easy_install.html#custom-installation-locations

> /home/jdanek/.cache/pypoetry/virtualenvs/skupper-router-7_an9NB3-py3.10/lib/python3.10/site-packages/pkg_resources/__init__.py:122: PkgResourcesDeprecationWarning: 2.0.1-32-g535900fe is an invalid version and will not be supported in a future release

> /home/jdanek/.cache/pypoetry/virtualenvs/skupper-router-7_an9NB3-py3.10/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.

(This is pretty much what @astitcher said for Proton. Modern approach is to build tar.gz or wheel and then install it with pip.)