### PR TITLE
Upgrade GitHub Actions build.yaml to Ubuntu 22.04 Jammy Jellyfish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -249,7 +249,7 @@ jobs:
 
       - name: Install Linux runtime/test dependencies
         run: |
-          sudo apt update; sudo apt install -y libdw1 libsasl2-2 libsasl2-modules sasl2-bin libjsoncpp1 libwebsockets15 libbenchmark1 pixz bubblewrap curl ncat gdb elfutils findutils file python3-dbg
+          sudo apt update; sudo apt install -y libdw1 libsasl2-2 libsasl2-modules sasl2-bin libjsoncpp25 libwebsockets16 libbenchmark1 pixz bubblewrap curl ncat gdb elfutils findutils file python3-dbg
 
       - name: Unpack archive
         run: tar -I pixz -xf archive.tar.xz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
@@ -202,7 +202,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         buildType: [Debug]
         runtimeCheck: [asan]
         protonGitRef:
@@ -307,7 +307,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         container: ['fedora']
         containerTag: ['37']
         cc: [gcc]
@@ -321,7 +321,7 @@ jobs:
         shards: [ 2 ]
         include:
           # CentOS 9
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             container: 'centos'
             containerTag: stream9
             cc: gcc
@@ -332,7 +332,7 @@ jobs:
             protonGitRef: ${{ github.event.inputs.protonBranch || 'main' }}
             shard: 1
             shards: 2
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             container: 'centos'
             containerTag: stream9
             cc: gcc
@@ -344,7 +344,7 @@ jobs:
             shard: 2
             shards: 2
           # CentOS 8
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             container: 'centos'
             containerTag: stream8
             cc: gcc
@@ -353,7 +353,7 @@ jobs:
             protonGitRef: ${{ github.event.inputs.protonBranch || 'main' }}
             shard: 1
             shards: 2
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             container: 'centos'
             containerTag: stream8
             cc: gcc
@@ -362,7 +362,7 @@ jobs:
             protonGitRef: ${{ github.event.inputs.protonBranch || 'main' }}
             shard: 2
             shards: 2
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             container: 'centos'
             containerTag: stream8
             cc: gcc
@@ -371,7 +371,7 @@ jobs:
             protonGitRef: 0.39.0
             shard: 1
             shards: 2
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             container: 'centos'
             containerTag: stream8
             cc: gcc
@@ -381,7 +381,7 @@ jobs:
             shard: 2
             shards: 2
           # unittest coverage
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             container: 'fedora'
             containerTag: 37
             cc: gcc
@@ -394,7 +394,7 @@ jobs:
             shard: 1
             shards: 1
           # clang
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             container: 'fedora'
             containerTag: 37
             cc: clang
@@ -404,7 +404,7 @@ jobs:
             protonGitRef: ${{ github.event.inputs.protonBranch || 'main' }}
             shard: 1
             shards: 2
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             container: 'fedora'
             containerTag: 37
             cc: clang
@@ -705,7 +705,7 @@ jobs:
     runs-on: '${{ matrix.os }}'
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04' ]
+        os: [ 'ubuntu-22.04' ]
 
     env:
       FORCE_COLOR: 1
@@ -740,7 +740,7 @@ jobs:
     runs-on: '${{ matrix.os }}'
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04' ]
+        os: [ 'ubuntu-22.04' ]
 
     env:
       DispatchBuildDir: ${{github.workspace}}/build
@@ -832,7 +832,7 @@ jobs:
     runs-on: '${{ matrix.os }}'
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04' ]
+        os: [ 'ubuntu-22.04' ]
         container: [ 'centos' ]
         containerTag: [ 'stream8' ]
 

--- a/tests/c_benchmarks/bm_tcp_adapter.cpp
+++ b/tests/c_benchmarks/bm_tcp_adapter.cpp
@@ -221,7 +221,7 @@ static void DISABLED_BM_TCPEchoServerLatencyWithoutQDR(benchmark::State &state)
     lm.latencyMeasureLoop(state, est.port());
 }
 
-BENCHMARK(DISABLED_BM_TCPEchoServerLatencyWithoutQDR)->Unit(benchmark::kMillisecond);
+// BENCHMARK(DISABLED_BM_TCPEchoServerLatencyWithoutQDR)->Unit(benchmark::kMillisecond);
 
 class DispatchRouterThreadTCPLatencyTest
 {
@@ -316,7 +316,7 @@ static void DISABLED_BM_TCPEchoServerLatency1QDRThread(benchmark::State &state)
     est.reset();
 }
 
-BENCHMARK(DISABLED_BM_TCPEchoServerLatency1QDRThread)->Unit(benchmark::kMillisecond);
+// BENCHMARK(DISABLED_BM_TCPEchoServerLatency1QDRThread)->Unit(benchmark::kMillisecond);
 
 static void DISABLED_BM_TCPEchoServerLatency1QDRSubprocess(benchmark::State &state)
 {
@@ -337,7 +337,7 @@ static void DISABLED_BM_TCPEchoServerLatency1QDRSubprocess(benchmark::State &sta
     }
 }
 
-BENCHMARK(DISABLED_BM_TCPEchoServerLatency1QDRSubprocess)->Unit(benchmark::kMillisecond);
+// BENCHMARK(DISABLED_BM_TCPEchoServerLatency1QDRSubprocess)->Unit(benchmark::kMillisecond);
 
 static void DISABLED_BM_TCPEchoServerLatency2QDRSubprocess(benchmark::State &state)
 {
@@ -364,4 +364,4 @@ static void DISABLED_BM_TCPEchoServerLatency2QDRSubprocess(benchmark::State &sta
     }
 }
 
-BENCHMARK(DISABLED_BM_TCPEchoServerLatency2QDRSubprocess)->Unit(benchmark::kMillisecond);
+// BENCHMARK(DISABLED_BM_TCPEchoServerLatency2QDRSubprocess)->Unit(benchmark::kMillisecond);


### PR DESCRIPTION
This is necessarily WIP because the image is not fully deployed on GitHub Actions hosted runners.

* Follow https://github.com/actions/virtual-environments/issues/5490 for updates.

Some info about software versions also on https://github.com/actions/virtual-environments/releases/tag/ubuntu22%2F20220522.1

Router currently affected by issues

* [x] https://github.com/skupperproject/skupper-router/issues/500