### PR TITLE
Fixes #495: export default qd_buffer_t size for tests

### DIFF
--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -153,8 +153,7 @@ elseif(RUNTIME_CHECK STREQUAL "asan" OR RUNTIME_CHECK STREQUAL "hwasan")
   set(SANITIZE_FLAGS "${common_sanitizer_flags} -fsanitize=${ASAN_VARIANTS} -DQD_MEMORY_DEBUG=1")
   # `detect_leaks=1` is set by default where it is available; better not to set it conditionally ourselves
   # https://github.com/openSUSE/systemd/blob/1270e56526cd5a3f485ae2aba975345c38860d37/docs/TESTING_WITH_SANITIZERS.md
-  # TODO(DISPATCH-2148) re-enable odr violation detection when Proton linking issue in test-sender is fixed
-  set(RUNTIME_ASAN_ENV_OPTIONS "disable_coredump=0 detect_odr_violation=0 strict_string_checks=1 detect_stack_use_after_return=1 check_initialization_order=1 strict_init_order=1 detect_invalid_pointer_pairs=2 suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
+  set(RUNTIME_ASAN_ENV_OPTIONS "disable_coredump=0 strict_string_checks=1 detect_stack_use_after_return=1 check_initialization_order=1 strict_init_order=1 detect_invalid_pointer_pairs=2 suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
   set(RUNTIME_LSAN_ENV_OPTIONS "disable_coredump=0 suppressions=${CMAKE_BINARY_DIR}/tests/lsan.supp")
   set(RUNTIME_UBSAN_ENV_OPTIONS "disable_coredump=0 print_stacktrace=1 print_summary=1")
 

--- a/include/qpid/dispatch/buffer.h
+++ b/include/qpid/dispatch/buffer.h
@@ -33,6 +33,7 @@ typedef struct qd_buffer_t qd_buffer_t;
 
 DEQ_DECLARE(qd_buffer_t, qd_buffer_list_t);
 
+#define QD_BUFFER_DEFAULT_SIZE 512
 extern size_t BUFFER_SIZE;
 
 /** A raw byte buffer .*/
@@ -43,16 +44,7 @@ struct qd_buffer_t {
 };
 
 /**
- * Set the initial buffer capacity to be allocated by future calls to qp_buffer.
- *
- * NOTICE:  This function is provided for testing purposes only.  It should not be invoked
- * in the production code.  If this function is called after the first buffer has been allocated,
- * the software WILL BE unstable and WILL crash.
- */
-void qd_buffer_set_size(size_t size);
-
-/**
- * Create a buffer with capacity set by last call to qd_buffer_set_size(), and data
+ * Create a buffer with capacity set to the value of BUFFER_SIZE, and data
  * content size of 0 bytes.
  */
 qd_buffer_t *qd_buffer(void);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -25,13 +25,20 @@
 #include <string.h>
 
 
-size_t BUFFER_SIZE     = 512;
+size_t BUFFER_SIZE = QD_BUFFER_DEFAULT_SIZE;
 
 ALLOC_DECLARE(qd_buffer_t);
 ALLOC_DEFINE_CONFIG(qd_buffer_t, sizeof(qd_buffer_t), &BUFFER_SIZE, 0);
 
 
-void qd_buffer_set_size(size_t size)
+/**
+ * Set the initial buffer capacity to be allocated by future calls to qp_buffer.
+ *
+ * NOTICE:  This function is provided for testing purposes only.  It should not be invoked
+ * in the production code.  If this function is called after the first buffer has been allocated,
+ * the software WILL BE unstable and WILL crash.
+ */
+void qd_buffer_set_size_test_only(size_t size)
 {
     BUFFER_SIZE = size;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ add_executable(unit_tests_size ${unit_test_size_SOURCES})
 target_link_libraries(unit_tests_size skupper-router)
 
 add_executable(test-sender test-sender.c)
-target_link_libraries(test-sender ${Proton_LIBRARIES} skupper-router)
+target_link_libraries(test-sender ${Proton_LIBRARIES})
 
 add_executable(test-receiver test-receiver.c)
 target_link_libraries(test-receiver ${Proton_LIBRARIES})

--- a/tests/run_unit_tests_size.c
+++ b/tests/run_unit_tests_size.c
@@ -22,6 +22,8 @@
 #include "qpid/dispatch/iterator.h"
 #include "qpid/dispatch/router.h"
 
+extern void qd_buffer_set_size_test_only(size_t size);
+
 void qd_log_initialize(void);
 void qd_log_finalize(void);
 void qd_error_initialize();
@@ -108,7 +110,7 @@ int main(int argc, char** argv)
     qd_alloc_initialize();
     qd_log_initialize();
     qd_error_initialize();
-    qd_buffer_set_size(buffer_size);
+    qd_buffer_set_size_test_only(buffer_size);
 
     result += router_id_tests();
     qd_router_id_initialize("0", "UnitTestRouter");

--- a/tests/test-sender.c
+++ b/tests/test-sender.c
@@ -20,8 +20,8 @@
 
 #define ADD_ANNOTATIONS 1
 
-#include "qpid/dispatch/buffer.h"
 #include "qpid/dispatch/message.h"
+#include "qpid/dispatch/buffer.h"
 
 #include "proton/connection.h"
 #include "proton/delivery.h"
@@ -46,7 +46,7 @@
 #define BODY_SIZE_SMALL  100L
 #define BODY_SIZE_MEDIUM ((long int)((4 * 1024) + 1))
 #define BODY_SIZE_LARGE  ((long int)((65 * 1024) + 1))
-#define BODY_SIZE_HUGE   ((long int)((BUFFER_SIZE * QD_QLIMIT_Q3_UPPER * 3) + 1))
+#define BODY_SIZE_HUGE   ((long int)((QD_BUFFER_DEFAULT_SIZE * QD_QLIMIT_Q3_UPPER * 3) + 1))
 
 #define DEFAULT_PRIORITY 4
 


### PR DESCRIPTION
This fixes the bug that required disabling the ASAN test for "one
definition rule" violations. By providing a public constant for the
default buffer size for use by the tests we can avoid attempting to
link the tests to the router libraries.

This patch also makes it harder to change the default buffer size by
inadvertantly calling a debug only interface.

Original fix by Andrew Stitcher.