### PR TITLE
Fixes #517 - Send SIGABRT to stuck subprocesses in test instead of SIGKILL

### DIFF
--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -39,6 +39,7 @@ import random
 import re
 import shlex
 import shutil
+import signal
 import socket
 import subprocess
 import sys
@@ -366,8 +367,8 @@ class Process(subprocess.Popen):
             try:
                 self.wait(TIMEOUT)
             except TimeoutExpired:
-                self.kill()
-                error("did not terminate properly, required kill()")
+                self.send_signal(signal.SIGABRT)  # so that we may get core dump
+                error("did not terminate properly, required SIGABORT")
 
         # at this point the process has terminated, either of its own accord or
         # due to the above terminate call.


### PR DESCRIPTION
Core will be dumped on SIGABRT and that may help with debugging.