### PR TITLE
Fixes #523 - Remove libpython suppressions in system-tests thanks to `PYTHONMALLOC` env var

### DIFF
--- a/.github/scripts/compile.sh
+++ b/.github/scripts/compile.sh
@@ -87,6 +87,7 @@ do_build () {
   cmake -S "$WORKING/" -B "$WORKING/build${suffix}" \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DRUNTIME_CHECK="${runtime_check}" \
+    -DSANITIZE_PYTHON=OFF \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
     -DProton_USE_STATIC_LIBS=ON \
     -DProton_DIR="$WORKING/proton_install${suffix}/usr/lib64/cmake/Proton" \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
         -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG
         -DUSE_BWRAP=ON
         -DRUNTIME_CHECK=${{matrix.runtimeCheck}}
-        -DSANITIZE_3RD_PARTY=ON
+        -DSANITIZE_PYTHON=OFF
         -DBUILD_BENCHMARKS=ON
 
       CCACHE_BASEDIR: ${{github.workspace}}
@@ -461,6 +461,10 @@ jobs:
         if: matrix.runtimeCheck == 'tsan'
         run: echo "RouterCMakeAsserts=OFF" >> $GITHUB_ENV
 
+      - name: disable Python leak checking on CentOS build
+        if: matrix.container == 'centos'
+        run: echo "RouterCMakeSanitizePython=OFF" >> $GITHUB_ENV
+
       - name: skupper-router cmake configure
         working-directory: ${{env.RouterBuildDir}}
         run: >
@@ -468,7 +472,7 @@ jobs:
             "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" \
             "-DCMAKE_BUILD_TYPE=${BuildType}" \
             "-DPYTHON_TEST_COMMAND='-m;pytest;-vs;--timeout=400;--junit-prefix=pytest.\${py_test_module};--junit-xml=junitxmls/\${py_test_module}.xml;--pyargs;\${py_test_module}'" \
-            ${RouterCMakeExtraArgs} -DQD_ENABLE_ASSERTIONS=${RouterCMakeAsserts}
+            ${RouterCMakeExtraArgs} -DQD_ENABLE_ASSERTIONS=${RouterCMakeAsserts} -DSANITIZE_PYTHON=${RouterCMakeSanitizePython}
 
       - name: skupper-router cmake build/install
         run: cmake --build "${RouterBuildDir}" --config ${BuildType} --target install --parallel 6

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -144,9 +144,8 @@ elseif(RUNTIME_CHECK STREQUAL "asan" OR RUNTIME_CHECK STREQUAL "hwasan")
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/tests/lsan.supp
         COMMAND bash -c 'cat ${CMAKE_SOURCE_DIR}/tests/lsan.supp > ${CMAKE_BINARY_DIR}/tests/lsan.supp'
-        COMMAND bash -c 'echo leak:/libpython3.*.so >> ${CMAKE_BINARY_DIR}/tests/lsan.supp'
-        DEPENDS ${CMAKE_SOURCE_DIR}/tests/lsan.supp
-        VERBATIM)
+        COMMAND bash -c 'echo "leak:/libpython3.*.so" >> ${CMAKE_BINARY_DIR}/tests/lsan.supp'
+        DEPENDS ${CMAKE_SOURCE_DIR}/tests/lsan.supp)
   endif ()
   add_custom_target(generate_lsan.supp ALL
         DEPENDS ${CMAKE_BINARY_DIR}/tests/lsan.supp)

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -144,7 +144,7 @@ elseif(RUNTIME_CHECK STREQUAL "asan" OR RUNTIME_CHECK STREQUAL "hwasan")
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/tests/lsan.supp
         COMMAND bash -c 'cat ${CMAKE_SOURCE_DIR}/tests/lsan.supp > ${CMAKE_BINARY_DIR}/tests/lsan.supp'
-        COMMAND bash -c 'echo "leak:/libpython3.*.so" >> ${CMAKE_BINARY_DIR}/tests/lsan.supp'
+        COMMAND bash -c 'echo leak:/libpython3.*.so >> ${CMAKE_BINARY_DIR}/tests/lsan.supp'
         DEPENDS ${CMAKE_SOURCE_DIR}/tests/lsan.supp
         VERBATIM)
   endif ()

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
                       <exclude>**/tsan.supp</exclude>
                       <exclude>**/asan.supp</exclude>
                       <exclude>**/lsan.supp</exclude>
-                      <exclude>**/lsan_3rdparty.supp</exclude>
                       <exclude>**/*.json.in</exclude>
                       <exclude>**/*.json</exclude>
                       <exclude>**/*.svg</exclude>

--- a/run.py.in
+++ b/run.py.in
@@ -84,6 +84,11 @@ env_vars = {
     'QPID_DISPATCH_RUNNER': qdrouterd_runner,
     'MALLOC_CHECK_': "3",      # 3 = print error and abort
     'MALLOC_PERTURB_': "153",  # 153 = 0x99 freed memory pattern
+    # https://docs.python.org/3/library/devmode.html
+    # https://pythondev.readthedocs.io/debug_tools.html
+    # https://pythonextensionpatterns.readthedocs.io/en/latest/debugging/debug_tools.html
+    'PYTHONMALLOC': 'malloc_debug',
+    'PYTHONDEVMODE': '1',
     'TSAN_OPTIONS': "${RUNTIME_TSAN_ENV_OPTIONS}",
     'ASAN_OPTIONS': "${RUNTIME_ASAN_ENV_OPTIONS}",
     'LSAN_OPTIONS': "${RUNTIME_LSAN_ENV_OPTIONS}",

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -33,6 +33,11 @@ fi
 if [[ $QDROUTERD_DEBUG = "gdb" ]]; then
     exec gdb -batch -ex "run" -ex "bt" --args skrouterd $ARGS
 elif [[ $QDROUTERD_DEBUG = "asan" ]]; then
+    # NOTE: keep environment in sync with that in run.py.in
+    export MALLOC_CHECK_=3
+    export MALLOC_PERTURB_=153
+    export PYTHONMALLOC=malloc_debug
+    export PYTHONDEVMODE=1
     exec skrouterd_asan $ARGS
 elif [[ $QDROUTERD_DEBUG = "tsan" ]]; then
     exec skrouterd_tsan $ARGS

--- a/tests/c_unittests/test_listener_startup.cpp
+++ b/tests/c_unittests/test_listener_startup.cpp
@@ -40,7 +40,7 @@ static bool regex_is_broken() {
 void check_amqp_listener_startup_log_message(qd_server_config_t config, std::string listen, std::string stop)
 {
     QDR qdr{};
-    CaptureCStream css(&stderr);
+    CaptureCStream css(stderr);
     qdr.initialize("./minimal_trace.conf");
 
     qd_listener_t *li = qd_server_listener(qdr.qd->server);
@@ -67,7 +67,7 @@ void check_amqp_listener_startup_log_message(qd_server_config_t config, std::str
 void check_http_listener_startup_log_message(qd_server_config_t config, std::string listen, std::string stop, std::string failed)
 {
     QDR qdr{};
-    CaptureCStream css(&stderr);
+    CaptureCStream css(stderr);
     qdr.initialize("./minimal_trace.conf");
 
     qd_listener_t *li = qd_server_listener(qdr.qd->server);

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -39,39 +39,6 @@ leak:__strdup
 #### Miscellaneous 3rd party libraries:
 ####
 
-### Python
-
-# these Python leaks happen even after simple Py_Initialize(); Py_Finalize();
-#  https://bugs.python.org/issue1635741
-leak:^_PyObject_Realloc
-leak:^PyObject_Malloc$
-leak:^PyThread_allocate_lock$
-
-# the PyMalloc mechanism is incompatible with Valgrind, it must be disabled or reported "leaks" must be suppressed
-#  https://pythonextensionpatterns.readthedocs.io/en/latest/debugging/debug_python.html#debug-version-of-python-memory-alloc-label
-leak:^PyMem_Malloc$
-leak:^PyMem_Calloc$
-leak:^PyMem_Realloc$
-leak:^_PyObject_GC_Resize$
-# Python uses these alloc functions if you define PYTHONDEVMODE=1
-leak:^_PyMem_DebugRawAlloc$
-leak:^_PyMem_DebugRawRealloc$
-# All the rest
-leak:^list_append$
-leak:^list_resize$
-leak:^_PyBytes_Resize$
-leak:^resize_compact$
-leak:^unicode_resize$
-# Python 2.7
-leak:^PyString_FromStringAndSize$
-leak:^PyString_FromString$
-leak:^PyObject_Realloc$
-leak:^_PyObject_GC_Malloc$
-leak:^_PyString_Resize$
-leak:^PyUnicodeUCS4_FromUnicode$
-leak:^PyList_Append$
-leak:^PyList_New$
-
 ### Qpid Proton
 
 # ISSUE #386: pn_record leaks when running h2spec test

--- a/tests/lsan_3rdparty.supp
+++ b/tests/lsan_3rdparty.supp
@@ -1,4 +1,0 @@
-# 3rd party lsan suppressions
-
-leak:/libpython2.*.so
-leak:/libpython3.*.so


### PR DESCRIPTION
* Depends on https://github.com/skupperproject/skupper-router/pull/519 which should be merged first
* Also depends on https://github.com/skupperproject/skupper-router/pull/524

Notice that with these changes, the suppressions listings in Fedora 35 job logs do not show any Python leaks. This is not true for CentOS 8 where the Python version is older and not yet asan-clean. Therefore, leaks from libpython need to be still suppressed on Ubuntu and CentOS.

I am unsure about Python Dev mode. It sounds rather nice, but from the docs it sounds rather, extensive. Using malloc debug version as memory allocator is, for tests, IMO sensible, so that part of the PR should be uncontentious.