### PR TITLE
Issue #470 - Fix c-unittests Python object leak introduced in the test

### DIFF
--- a/tests/c_unittests/test_connection_manager_static.cpp
+++ b/tests/c_unittests/test_connection_manager_static.cpp
@@ -44,7 +44,8 @@ QD_EXPORT void qd_connection_manager_delete_ssl_profile(qd_dispatch_t *qd, void 
 static void check_password(qd_dispatch_t *qd, const char *password, const char *expected, bool expect_success = true)
 {
     PyObject *pyObject = PyDict_New();
-    PyDict_SetItemString(pyObject, "password", PyUnicode_FromString(password));
+    PyObject *item     = PyUnicode_FromString(password);
+    PyDict_SetItemString(pyObject, "password", item);
     qd_entity_t *entity              = reinterpret_cast<qd_entity_t *>(pyObject);
     qd_config_ssl_profile_t *profile = qd_dispatch_configure_ssl_profile(qd, entity);
     if (expect_success) {
@@ -54,6 +55,8 @@ static void check_password(qd_dispatch_t *qd, const char *password, const char *
     } else {
         REQUIRE(profile == nullptr);
     }
+    Py_DECREF(item);
+    Py_DECREF(pyObject);
 }
 
 TEST_CASE("qd_dispatch_configure_ssl_profile")


### PR DESCRIPTION
The `qd_config_process_password` test leaks Python objects. Here are three approaches what can be done about it.

# Manual decref in the happy case

```diff
Index: tests/c_unittests/test_connection_manager_static.cpp
<+>UTF-8
===================================================================
diff --git a/tests/c_unittests/test_connection_manager_static.cpp b/tests/c_unittests/test_connection_manager_static.cpp
--- a/tests/c_unittests/test_connection_manager_static.cpp	(revision fae67b60967210522644a1ddb9980d11e9b7b62a)
+++ b/tests/c_unittests/test_connection_manager_static.cpp	(revision 0de6d8407a241d4da4ea50b4f01c1ad66e4357bf)
@@ -44,7 +44,8 @@
 static void check_password(qd_dispatch_t *qd, const char *password, const char *expected, bool expect_success = true)
 {
     PyObject *pyObject = PyDict_New();
-    PyDict_SetItemString(pyObject, "password", PyUnicode_FromString(password));
+    PyObject *item     = PyUnicode_FromString(password);
+    PyDict_SetItemString(pyObject, "password", item);
     qd_entity_t *entity              = reinterpret_cast<qd_entity_t *>(pyObject);
     qd_config_ssl_profile_t *profile = qd_dispatch_configure_ssl_profile(qd, entity);
     if (expect_success) {
@@ -54,6 +55,8 @@
     } else {
         REQUIRE(profile == nullptr);
     }
+    Py_DECREF(item);
+    Py_DECREF(pyObject);
 }

 TEST_CASE("qd_dispatch_configure_ssl_profile")
```

The above would still leak if the test fails, but then we have bigger problems than just a Python leak, so I think it is acceptable.

# Use unique_ptr with custom deleter

```cpp
static void check_password(qd_dispatch_t *qd, const char *password, const char *expected, bool expect_success = true)
{
    unique_PyObject pyObject(PyDict_New());
    unique_PyObject item(PyUnicode_FromString(password));
    PyDict_SetItemString(pyObject.get(), "password", item.get());
    qd_entity_t *entity              = reinterpret_cast<qd_entity_t *>(pyObject.get());
    qd_config_ssl_profile_t *profile = qd_dispatch_configure_ssl_profile(qd, entity);
    if (expect_success) {
        REQUIRE(profile != nullptr);
        CHECK(profile->ssl_password == expected);
        qd_connection_manager_delete_ssl_profile(qd, profile);
    } else {
        REQUIRE(profile == nullptr);
    }
}
```

```
struct pydecref_deleter {
    void operator()(PyObject *p) const
    {
        Py_DECREF(p);
    }
};
using unique_PyObject = std::unique_ptr<PyObject, pydecref_deleter>;
```

This is annoying due to having to call .get() all the time, makes code look unlike C

# Custom wrapper class with implicit conversion operator

Class taken from https://pythonextensionpatterns.readthedocs.io/en/latest/cpp_and_cpython.html

```
#include "python_utils.hpp"

static void check_password(qd_dispatch_t *qd, const char *password, const char *expected, bool expect_success = true)
{
    NewRef pyObject(PyDict_New());
    NewRef item(PyUnicode_FromString(password));

    PyDict_SetItemString(pyObject, "password", item);
    qd_entity_t *entity              = reinterpret_cast<qd_entity_t *>(static_cast<PyObject *>(pyObject));
    qd_config_ssl_profile_t *profile = qd_dispatch_configure_ssl_profile(qd, entity);
    if (expect_success) {
        REQUIRE(profile != nullptr);
        CHECK(profile->ssl_password == expected);
        qd_connection_manager_delete_ssl_profile(qd, profile);
    } else {
        REQUIRE(profile == nullptr);
    }
}
```

This is quite nice, except for the part where it is necessary to turn NewRef into qd_entity_t, requiring two step process

```
qd_entity_t *entity              = reinterpret_cast<qd_entity_t *>(static_cast<PyObject *>(pyObject));
```

I am personally inclined towards the first option, but I intend to raise a PR that adds the helper code for the third option, because the ability to work like this looks useful.