### PR TITLE
Make skupper-router compile better against Proton 0.38 (current main)

### DIFF
--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -952,8 +952,8 @@ static void* http_thread_run(void* v) {
                 break;
             case W_WAKE: {
                 connection_t *c = w.value;
-                pn_collector_put(c->driver.collector, PN_OBJECT, c->driver.connection,
-                                 PN_CONNECTION_WAKE);
+                pn_collector_put_object(c->driver.collector, c->driver.connection,
+                                        PN_CONNECTION_WAKE);
                 handle_events(c);
                 break;
             }


### PR DESCRIPTION
These are a couple of small changes which accounts for some small changes happening on Proton main for release in 0.38.

The initial change - ``pn_collector_put`` -> ``pn_collector_put_object`` - will not compile against 0.37 but needs Proton main currently and should compile against 0.38 when it is released.

Arguably the ``pn_record_def`` call should always have used ``PN_VOID`` as the type being stored is not a ``PN_OBJECT`` type but just a normal C struct.

So I expect this change should be committed when Proton 0.38 is released.

