### PR TITLE
Fixes #542 - Added a callback to confirm the cancellation of an address-watch.

### DIFF
--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -199,6 +199,16 @@ typedef void (*qdr_address_watch_update_t)(void     *context,
                                            uint32_t  remote_consumers,
                                            uint32_t  local_producers);
 
+
+/**
+ * Handler to confirm the cancellation (unwatch) of an address-watch.
+ *
+ * When this call is invoked, it is guaranteed that no further updates shall be received for this watch.
+ *
+ * @param context The opaque context supplied in the call to qdr_core_watch_address.
+ */
+typedef void (*qdr_address_watch_cancel_t)(void *context);
+
 /**
  * qdr_core_watch_address
  *
@@ -208,7 +218,8 @@ typedef void (*qdr_address_watch_update_t)(void     *context,
  * @param core Pointer to the core module
  * @param address The address to be watched
  * @param aclass Address class character
- * @param on_watch The handler function
+ * @param on_update The update handler function
+ * @param on_cancel The cancel handler function
  * @param context The opaque context sent to the handler on all invocations
  * @return Watch handle to be used when canceling the watch
  */
@@ -216,7 +227,8 @@ qdr_watch_handle_t qdr_core_watch_address(qdr_core_t                 *core,
                                           const char                 *address,
                                           char                        aclass,
                                           qd_address_treatment_t      treatment_hint,
-                                          qdr_address_watch_update_t  on_watch,
+                                          qdr_address_watch_update_t  on_update,
+                                          qdr_address_watch_cancel_t  on_cancel,
                                           void                       *context);
 
 /**
@@ -225,8 +237,7 @@ qdr_watch_handle_t qdr_core_watch_address(qdr_core_t                 *core,
  * Cancel an address watch subscription.  It is safe to invoke this function from an IO thread.
  *
  * Note that it is possible for the watch update handler to be invoked after the unwatch call is made.
- * This is because a watch event may already be in flight during the call to unwatch_address.  The caller
- * must handle this case.
+ * Wait until the on_cancel handler is invoked to clean up any related resources.
  * 
  * @param core Pointer to the core module
  * @param handle Watch handle returned by qdr_core_watch_address

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -1465,6 +1465,12 @@ static void _on_watched_address_update(void     *context,
     }
 }
 
+
+static void _on_watched_address_cancel(void *context)
+{
+    // Intentionally left blank
+}
+
 qd_error_t qd_load_tcp_adaptor_config(qd_dispatch_t *qd, qd_tcp_adaptor_config_t *config, qd_entity_t* entity)
 {
     // Make a call to the function that loads the common adaptor config.
@@ -1510,6 +1516,7 @@ QD_EXPORT qd_tcp_listener_t *qd_dispatch_configure_tcp_listener(qd_dispatch_t *q
                                               QD_ITER_HASH_PREFIX_MOBILE,
                                               qd->default_treatment,
                                               _on_watched_address_update,
+                                              _on_watched_address_cancel,
                                               (void*) ((uintptr_t) li->identity));
 
     qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,

--- a/src/protocol_log.c
+++ b/src/protocol_log.c
@@ -1369,9 +1369,9 @@ static void _plog_init_address_watch_TH(plog_work_t *work, bool discard)
         _plog_strncat_id(event_address_my, 70, &local_router->identity);
 
         all_address_watch_handle = qdr_core_watch_address(core, event_address_all, 'M',
-                                                          QD_TREATMENT_MULTICAST_ONCE, _plog_on_all_address_watch, core);
+                                                          QD_TREATMENT_MULTICAST_ONCE, _plog_on_all_address_watch, 0, core);
         my_address_watch_handle  = qdr_core_watch_address(core, event_address_my,  'M',
-                                                          QD_TREATMENT_MULTICAST_ONCE, _plog_on_my_address_watch, core);
+                                                          QD_TREATMENT_MULTICAST_ONCE, _plog_on_my_address_watch, 0, core);
     }
 }
 

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -156,6 +156,7 @@ struct qdr_action_t {
             bool                        exclude_inprocess;
             bool                        control;
             qdr_address_watch_update_t  watch_handler;
+            qdr_address_watch_cancel_t  cancel_handler;
             void                       *context;
             uint32_t                    value32_1;
         } io;
@@ -240,7 +241,8 @@ struct qdr_general_work_t {
     qdr_delivery_t              *delivery;
     qdr_delivery_cleanup_list_t  delivery_cleanup_list;
     qdr_global_stats_handler_t   stats_handler;
-    qdr_address_watch_update_t   watch_handler;
+    qdr_address_watch_update_t   watch_update_handler;
+    qdr_address_watch_cancel_t   watch_cancel_handler;
     void                        *context;
 };
 


### PR DESCRIPTION
This is an improvement (I think) over the previous fix for #533.