### PR TITLE
Fixes #520: refactor shutdown to clean pending general work items

### DIFF
--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -420,7 +420,12 @@ typedef struct {
     size_t deliveries_redirected_to_fallback;
 }  qdr_global_stats_t;
 ALLOC_DECLARE(qdr_global_stats_t);
-typedef void (*qdr_global_stats_handler_t) (void *context);
+
+
+// if discard is true the router has shut down and the handler should release
+// any resources associated with the request without scheduling additional
+// work.
+typedef void (*qdr_global_stats_handler_t) (void *context, bool discard);
 void qdr_request_global_stats(qdr_core_t *core, qdr_global_stats_t *stats, qdr_global_stats_handler_t callback, void *context);
 
 

--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -450,10 +450,10 @@ static void connection_wake(qd_connection_t *qd_conn)
 /**
  * Called on router worker thread
  */
-static void handle_stats_results(void *context)
+static void handle_stats_results(void *context, bool discard)
 {
     stats_request_state_t* state = (stats_request_state_t*) context;
-    if (state->wsi_deleted) {
+    if (state->wsi_deleted || discard) {
         free(state);
     } else {
         qd_http_server_t *hs = state->server;

--- a/src/router_core/address_watch.c
+++ b/src/router_core/address_watch.c
@@ -32,8 +32,8 @@ struct qdr_address_watch_t {
 ALLOC_DECLARE(qdr_address_watch_t);
 ALLOC_DEFINE(qdr_address_watch_t);
 
-static void qdr_watch_invoker(qdr_core_t *core, qdr_general_work_t *work);
-static void qdr_watch_cancel_invoker(qdr_core_t *core, qdr_general_work_t *work);
+static void qdr_watch_invoker(qdr_core_t *core, qdr_general_work_t *work, bool discard);
+static void qdr_watch_cancel_invoker(qdr_core_t *core, qdr_general_work_t *work, bool discard);
 static void qdr_core_watch_address_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
 static void qdr_core_unwatch_address_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
 static void qdr_address_watch_free_CT(qdr_core_t *core, qdr_address_watch_t *watch);
@@ -120,15 +120,17 @@ static void qdr_address_watch_free_CT(qdr_core_t *core, qdr_address_watch_t *wat
 }
 
 
-static void qdr_watch_invoker(qdr_core_t *core, qdr_general_work_t *work)
+static void qdr_watch_invoker(qdr_core_t *core, qdr_general_work_t *work, bool discard)
 {
-    work->watch_update_handler(work->context,
-                               work->local_consumers, work->in_proc_consumers, work->remote_consumers, work->local_producers);
+    if (!discard)
+        work->watch_update_handler(work->context,
+                                   work->local_consumers, work->in_proc_consumers, work->remote_consumers, work->local_producers);
 }
 
 
-static void qdr_watch_cancel_invoker(qdr_core_t *core, qdr_general_work_t *work)
+static void qdr_watch_cancel_invoker(qdr_core_t *core, qdr_general_work_t *work, bool discard)
 {
+    // @TODO(kgiusti): pass discard flag to handler to allow it to clean up the context
     work->watch_cancel_handler(work->context);
 }
 

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -318,8 +318,14 @@ static void qdr_settle_subscription_delivery_CT(qdr_core_t *core, qdr_action_t *
 }
 
 
-void qdr_forward_on_message(qdr_core_t *core, qdr_general_work_t *work)
+void qdr_forward_on_message(qdr_core_t *core, qdr_general_work_t *work, bool discard)
 {
+    if (discard) {
+        qd_message_free(work->msg);
+        qdr_delivery_decref(core, work->delivery, "qdr_forward_on_message - discard on shutdown");
+        return;
+    }
+
     qdr_error_t *error = 0;
     uint64_t disposition = work->on_message(work->on_message_context, work->msg, work->maskbit,
                                             work->inter_router_cost, work->in_conn_id, work->policy_spec, &error);

--- a/src/router_core/route_tables.c
+++ b/src/router_core/route_tables.c
@@ -720,21 +720,24 @@ static void qdr_unsubscribe_CT(qdr_core_t *core, qdr_action_t *action, bool disc
 // Call-back Functions
 //==================================================================================
 
-static void qdr_do_set_mobile_seq(qdr_core_t *core, qdr_general_work_t *work)
+static void qdr_do_set_mobile_seq(qdr_core_t *core, qdr_general_work_t *work, bool discard)
 {
-    core->rt_set_mobile_seq(core->rt_context, work->maskbit, work->mobile_seq);
+    if (!discard)
+        core->rt_set_mobile_seq(core->rt_context, work->maskbit, work->mobile_seq);
 }
 
 
-static void qdr_do_set_my_mobile_seq(qdr_core_t *core, qdr_general_work_t *work)
+static void qdr_do_set_my_mobile_seq(qdr_core_t *core, qdr_general_work_t *work, bool discard)
 {
-    core->rt_set_my_mobile_seq(core->rt_context, work->mobile_seq);
+    if (!discard)
+        core->rt_set_my_mobile_seq(core->rt_context, work->mobile_seq);
 }
 
 
-static void qdr_do_link_lost(qdr_core_t *core, qdr_general_work_t *work)
+static void qdr_do_link_lost(qdr_core_t *core, qdr_general_work_t *work, bool discard)
 {
-    core->rt_link_lost(core->rt_context, work->maskbit);
+    if (!discard)
+        core->rt_link_lost(core->rt_context, work->maskbit);
 }
 
 

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -220,8 +220,14 @@ DEQ_DECLARE(qdr_delivery_cleanup_t, qdr_delivery_cleanup_list_t);
 // a zero-delay timer and are processed by one thread at a time.  General
 // actions occur in-order and are not run concurrently.
 //
+// If the discard parameter to the handler is true the router is in the process
+// of shutting down and cleaning up any outstanding general work items. At this
+// point all threads have been shutdown and the handler must avoid scheduling
+// any further work and should simply release any resources held by the work
+// item.
+//
 typedef struct qdr_general_work_t qdr_general_work_t;
-typedef void (*qdr_general_work_handler_t) (qdr_core_t *core, qdr_general_work_t *work);
+typedef void (*qdr_general_work_handler_t) (qdr_core_t *core, qdr_general_work_t *work, bool discard);
 
 struct qdr_general_work_t {
     DEQ_LINKS(qdr_general_work_t);

--- a/src/router_core/router_core_thread.c
+++ b/src/router_core/router_core_thread.c
@@ -103,8 +103,9 @@ static void qdr_activate_connections_CT(qdr_core_t *core)
 }
 
 
-static void qdr_do_message_to_addr_free(qdr_core_t *core, qdr_general_work_t *work)
+static void qdr_do_message_to_addr_free(qdr_core_t *core, qdr_general_work_t *work, bool discard)
 {
+    // safe to ignore discard flag since this handler simply frees resources
     qdr_delivery_cleanup_t *cleanup = DEQ_HEAD(work->delivery_cleanup_list);
 
     while (cleanup) {


### PR DESCRIPTION
Refactor the general work callback interface to take a flag that
indicates the router is being shut down. This is similar to the
existing router core action handlers.