### PR TITLE
Remove useless `parse_failover_property_list` suppression

### DIFF
--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -5,9 +5,6 @@
 # to be triaged; pretty much all tests
 leak:^load_server_config$
 
-# to be triaged; system_tests_handle_failover
-leak:^parse_failover_property_list$
-
 # to be triaged; system_tests_http
 leak:^callback_healthz$
 leak:^callback_metrics$


### PR DESCRIPTION
This suppression does not suppress anything.