### PR TITLE
Run Fedora GHA test jobs with `-j12` threads again

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -505,9 +505,6 @@ jobs:
           ulimit -c unlimited
           
           threads=12
-          if [[ "${{ matrix.runtimeCheck }}" == "tsan" ]]; then
-            threads=2
-          fi
 
           ctest --timeout 1200 -V --output-junit=Testing/Test.xml --output-on-failure --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j${threads} ${{env.RouterCTestExtraArgs}}
 


### PR DESCRIPTION
* Undo https://github.com/skupperproject/skupper-router/pull/150

This makes the runs somewhat faster, and more sensitive to timing flakes.