### PR TITLE
Fixes #799: Split the pooled type declarations into weak-reffed and the non-weak-reffed

### DIFF
--- a/include/qpid/dispatch/alloc_pool.h
+++ b/include/qpid/dispatch/alloc_pool.h
@@ -108,14 +108,14 @@ static inline void *qd_alloc_deref_safe_ptr(const qd_alloc_safe_ptr_t *sp)
 #define ALLOC_DECLARE(T) \
     extern __thread qd_alloc_pool_t *__local_pool_##T; \
     T *new_##T(void);    \
-    void free_##T(T *p)
+    void free_##T(T *p); \
+    qd_alloc_stats_t *alloc_stats_##T(void)
 
 #define ALLOC_DECLARE_SAFE(T) \
     ALLOC_DECLARE(T); \
     typedef qd_alloc_safe_ptr_t T##_sp; \
     void set_safe_ptr_##T(T *p, T##_sp *sp); \
-    T *safe_deref_##T(T##_sp sp); \
-    qd_alloc_stats_t *alloc_stats_##T(void)
+    T *safe_deref_##T(T##_sp sp)
 
 /**
  * Define allocator configuration.

--- a/include/qpid/dispatch/alloc_pool.h
+++ b/include/qpid/dispatch/alloc_pool.h
@@ -108,7 +108,10 @@ static inline void *qd_alloc_deref_safe_ptr(const qd_alloc_safe_ptr_t *sp)
 #define ALLOC_DECLARE(T) \
     extern __thread qd_alloc_pool_t *__local_pool_##T; \
     T *new_##T(void);    \
-    void free_##T(T *p); \
+    void free_##T(T *p)
+
+#define ALLOC_DECLARE_SAFE(T) \
+    ALLOC_DECLARE(T); \
     typedef qd_alloc_safe_ptr_t T##_sp; \
     void set_safe_ptr_##T(T *p, T##_sp *sp); \
     T *safe_deref_##T(T##_sp sp); \
@@ -123,15 +126,21 @@ static inline void *qd_alloc_deref_safe_ptr(const qd_alloc_safe_ptr_t *sp)
     __thread qd_alloc_pool_t *__local_pool_##T = 0;                     \
     T *new_##T(void) { return (T*) qd_alloc(&__desc_##T, &__local_pool_##T); }  \
     void free_##T(T *p) { qd_dealloc(&__desc_##T, &__local_pool_##T, (char*) p); } \
+    qd_alloc_stats_t *alloc_stats_##T(void) { return __desc_##T.stats; } \
+    void *unused##T
+
+#define ALLOC_DEFINE_CONFIG_SAFE(T,S,A,C)                                \
+    ALLOC_DEFINE_CONFIG(T,S,A,C); \
     void set_safe_ptr_##T(T *p, T##_sp *sp) { qd_alloc_set_safe_ptr(sp, (void*)p); } \
     T *safe_deref_##T(T##_sp sp) { return (T*) qd_alloc_deref_safe_ptr((qd_alloc_safe_ptr_t*) &(sp)); } \
-    qd_alloc_stats_t *alloc_stats_##T(void) { return __desc_##T.stats; } \
     void *unused##T
 
 /**
  * Define functions new_T and alloc_T
  */
 #define ALLOC_DEFINE(T) ALLOC_DEFINE_CONFIG(T, sizeof(T), 0, 0)
+
+#define ALLOC_DEFINE_SAFE(T) ALLOC_DEFINE_CONFIG_SAFE(T, sizeof(T), 0, 0)
 
 void qd_alloc_initialize(void);
 void qd_alloc_debug_dump(const char *file);

--- a/include/qpid/dispatch/container.h
+++ b/include/qpid/dispatch/container.h
@@ -101,7 +101,7 @@ typedef struct qd_node_t     qd_node_t;
 typedef struct qd_session_t  qd_session_t;
 typedef struct qd_link_t     qd_link_t;
 
-ALLOC_DECLARE(qd_link_t);
+ALLOC_DECLARE_SAFE(qd_link_t);
 DEQ_DECLARE(qd_link_t, qd_link_list_t);
 
 typedef bool (*qd_container_delivery_handler_t)                  (void *node_context, qd_link_t *link);

--- a/src/adaptors/http1/http1_adaptor.c
+++ b/src/adaptors/http1/http1_adaptor.c
@@ -57,7 +57,7 @@
 const char *http1_alpn_protocols[HTTP1_NUM_ALPN_PROTOCOLS] = {"http/1.1", "http/1.0"};
 
 ALLOC_DEFINE(qdr_http1_out_data_t);
-ALLOC_DEFINE(qdr_http1_connection_t);
+ALLOC_DEFINE_SAFE(qdr_http1_connection_t);
 
 
 qdr_http1_adaptor_t *qdr_http1_adaptor;

--- a/src/adaptors/http1/http1_private.h
+++ b/src/adaptors/http1/http1_private.h
@@ -187,7 +187,7 @@ struct qdr_http1_connection_t {
     bool output_closed;
     bool input_closed;
 };
-ALLOC_DECLARE(qdr_http1_connection_t);
+ALLOC_DECLARE_SAFE(qdr_http1_connection_t);
 
 // special AMQP application properties keys for HTTP1 metadata headers
 // ':' prefix is illegal for HTTP headers, ensures no collisions with

--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -48,7 +48,7 @@ const char *CONTENT_ENCODING = "content-encoding";
 #define WRITE_BUFFERS 4
 #define ARRLEN(x) (sizeof(x) / sizeof(x[0]))
 
-ALLOC_DEFINE(qdr_http2_stream_data_t);
+ALLOC_DEFINE_SAFE(qdr_http2_stream_data_t);
 ALLOC_DEFINE(qdr_http2_connection_t);
 
 typedef struct qdr_http2_adaptor_t {

--- a/src/adaptors/http2/http2_adaptor.h
+++ b/src/adaptors/http2/http2_adaptor.h
@@ -166,7 +166,7 @@ struct qdr_http2_connection_t {
     DEQ_LINKS(qdr_http2_connection_t);
  };
 
-ALLOC_DECLARE(qdr_http2_stream_data_t);
+ALLOC_DECLARE_SAFE(qdr_http2_stream_data_t);
 ALLOC_DECLARE(qdr_http2_connection_t);
 
 #endif // __http2_adaptor_h__

--- a/src/adaptors/tcp/tcp_adaptor.c
+++ b/src/adaptors/tcp/tcp_adaptor.c
@@ -137,8 +137,8 @@ struct qdr_tcp_connection_t {
 };
 
 DEQ_DECLARE(qdr_tcp_connection_t, qdr_tcp_connection_list_t);
-ALLOC_DECLARE(qdr_tcp_connection_t);
-ALLOC_DEFINE(qdr_tcp_connection_t);
+ALLOC_DECLARE_SAFE(qdr_tcp_connection_t);
+ALLOC_DEFINE_SAFE(qdr_tcp_connection_t);
 ALLOC_DEFINE(qd_tcp_adaptor_config_t);
 
 typedef struct qdr_tcp_adaptor_t {

--- a/src/container.c
+++ b/src/container.c
@@ -72,7 +72,7 @@ struct qd_link_t {
     uint64_t                    link_id;
 };
 
-ALLOC_DEFINE(qd_link_t);
+ALLOC_DEFINE_SAFE(qd_link_t);
 ALLOC_DEFINE(qd_link_ref_t);
 
 /** Encapsulates a proton session */

--- a/src/message.c
+++ b/src/message.c
@@ -92,7 +92,7 @@ static const char * const section_names[QD_DEPTH_ALL + 1] = {
 
 PN_HANDLE(PN_DELIVERY_CTX)
 
-ALLOC_DEFINE_CONFIG(qd_message_t, sizeof(qd_message_pvt_t), 0, 0);
+ALLOC_DEFINE_CONFIG_SAFE(qd_message_t, sizeof(qd_message_pvt_t), 0, 0);
 ALLOC_DEFINE(qd_message_content_t);
 ALLOC_DEFINE(qd_message_stream_data_t);
 

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -173,7 +173,7 @@ struct qd_message_pvt_t {
     sys_atomic_t                   send_complete;   // Message has been been completely sent
 };
 
-ALLOC_DECLARE(qd_message_t);
+ALLOC_DECLARE_SAFE(qd_message_t);
 ALLOC_DECLARE(qd_message_content_t);
 
 #define MSG_CONTENT(m)     (((qd_message_pvt_t*) m)->content)

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -42,7 +42,7 @@ static void qdr_link_detach_sent(qdr_link_t *link);
 static void qdr_link_processing_complete(qdr_core_t *core, qdr_link_t *link);
 static void qdr_connection_group_cleanup_CT(qdr_core_t *core, qdr_connection_t *conn);
 
-ALLOC_DEFINE(qdr_connection_t);
+ALLOC_DEFINE_SAFE(qdr_connection_t);
 ALLOC_DEFINE(qdr_connection_work_t);
 
 //==================================================================================

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -31,13 +31,13 @@ ALLOC_DEFINE(qdr_address_t);
 ALLOC_DEFINE(qdr_address_config_t);
 ALLOC_DEFINE(qdr_node_t);
 ALLOC_DEFINE(qdr_delivery_ref_t);
-ALLOC_DEFINE(qdr_link_t);
+ALLOC_DEFINE_SAFE(qdr_link_t);
 ALLOC_DEFINE(qdr_router_ref_t);
 ALLOC_DEFINE(qdr_link_ref_t);
 ALLOC_DEFINE(qdr_delivery_cleanup_t);
 ALLOC_DEFINE(qdr_general_work_t);
 ALLOC_DEFINE(qdr_link_work_t);
-ALLOC_DEFINE(qdr_connection_ref_t);
+ALLOC_DEFINE_SAFE(qdr_connection_ref_t);
 ALLOC_DEFINE(qdr_connection_info_t);
 ALLOC_DEFINE(qdr_subscription_ref_t);
 

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -51,10 +51,10 @@ ALLOC_DECLARE(qdr_router_ref_t);
 ALLOC_DECLARE(qdr_link_ref_t);
 ALLOC_DECLARE(qdr_auto_link_t);
 ALLOC_DECLARE(qdr_conn_identifier_t);
-ALLOC_DECLARE(qdr_connection_ref_t);
+ALLOC_DECLARE_SAFE(qdr_connection_ref_t);
 
-ALLOC_DECLARE(qdr_connection_t);
-ALLOC_DECLARE(qdr_link_t);
+ALLOC_DECLARE_SAFE(qdr_connection_t);
+ALLOC_DECLARE_SAFE(qdr_link_t);
 
 #include "core_attach_address_lookup.h"
 #include "core_events.h"

--- a/tests/alloc_test.c
+++ b/tests/alloc_test.c
@@ -30,8 +30,8 @@ typedef struct {
 
 qd_alloc_config_t config = {3, 7, 10};
 
-ALLOC_DECLARE(object_t);
-ALLOC_DEFINE_CONFIG(object_t, sizeof(object_t), 0, &config);
+ALLOC_DECLARE_SAFE(object_t);
+ALLOC_DEFINE_CONFIG_SAFE(object_t, sizeof(object_t), 0, &config);
 
 
 static char* check_stats(qd_alloc_stats_t *stats, uint64_t ah, uint64_t fh, uint64_t ht, uint64_t rt, uint64_t rg)


### PR DESCRIPTION
There are three reasons why use memory pool for a type. First, because it makes allocation/deallocation faster, second because it prevents memory fragmentation, and third it allows holding weak references to the type.

The pool is constrained by having to support these use cases. Namely, a pool that supports weak references may never free any memory to the operating system, because it must be always able to dereference any previously obtained weak pointer.

This PR creates a separate API to declare weak-reffed types, so it is now obvious what types need weak references. There are no changes to functionality.

Note the functions mentioned in the second commit, which bypass the usual weak pointer API and mess with weak pointers under the table. This approach makes it look like the types don't get used with weak pointers, but they actually do get weak-pointed. (This only becomes visible when you (for testing purposes) replace pooled allocation for the non-weak types with malloc/free; the way the PR does things, the underhanded approach can still be used to create weak references even though type was not declared to support it.)