### PR TITLE
Fixes #582: prevent restarting the activation timer once it is scheduled

### DIFF
--- a/src/adaptors/http2/http2_adaptor.h
+++ b/src/adaptors/http2/http2_adaptor.h
@@ -143,11 +143,11 @@ struct qdr_http2_connection_t {
     bool                      connection_established;
     bool                      grant_initial_buffers;
     bool                      ingress;
-    bool                      timer_scheduled;
     bool                      client_magic_sent;
     bool                      delete_egress_connections;  // If set to true, the egress qdr_connection_t and qdr_http2_connection_t objects will be deleted
     bool                      goaway_received;
     bool                      tls_error;
+    sys_atomic_t              activate_scheduled;  // 1 == activate timer scheduled
     sys_atomic_t              raw_closed_read;
     sys_atomic_t              raw_closed_write;
     bool                      q2_blocked;      // send a connection level WINDOW_UPDATE frame to tell the client to stop sending data.


### PR DESCRIPTION
I'm not in love with this fix, it can probably be done better.
It fixes the problem simply by preventing the re-scheduling of the activation timer when it is running.  This fixes the problem by preventing the core activation from re-setting the timer to zero when it is already timing the reconnect.

I'm not confident I understand the interaction between the core/connection/timer threads to come up with a better one...