### PR TITLE
Issue #609 - Reset the .data and .bss sections for every unittest

### DIFF
--- a/tests/c_unittests/helpers.cpp
+++ b/tests/c_unittests/helpers.cpp
@@ -23,30 +23,24 @@
 
 std::mutex QDR::startup_shutdown_lock;
 
-// variable for quick check
-static int pepa = 42;
-
-// writes to memory between global variables are reported as buffer overflows by asan
+// disable sanitizer, otherwise writes to memory between global variables are reported as buffer overflows
 ATTRIBUTE_NO_SANITIZE_ADDRESS
 void reset_static_data()
 {
-    // global variable, ok to leak it
-    static char * x;
+    static char *x;
 
     size_t s = BSS_END - DATA_START;
 
     // memset is always sanitized, so access memory as chars in a loop
+
     if (x == NULL) {
         x = (char *) malloc(s);
         for (size_t i = 0; i < s; i++) {
-            *(x+i) = *(DATA_START + i);
+            *(x + i) = *(DATA_START + i);
         }
     } else {
         for (size_t i = 0; i < s; i++) {
-            *(DATA_START + i) = *(x+i);
+            *(DATA_START + i) = *(x + i);
         }
     }
-
-    // quick check, see that pepa does not grow in stderr output
-    fprintf(stderr, "pepa: %d\n", pepa++);
 }

--- a/tests/c_unittests/helpers.cpp
+++ b/tests/c_unittests/helpers.cpp
@@ -19,4 +19,34 @@
 
 #include "helpers.hpp"
 
+#include "../src/qd_asan_interface.h"
+
 std::mutex QDR::startup_shutdown_lock;
+
+// variable for quick check
+static int pepa = 42;
+
+// writes to memory between global variables are reported as buffer overflows by asan
+ATTRIBUTE_NO_SANITIZE_ADDRESS
+void reset_static_data()
+{
+    // global variable, ok to leak it
+    static char * x;
+
+    size_t s = BSS_END - DATA_START;
+
+    // memset is always sanitized, so access memory as chars in a loop
+    if (x == NULL) {
+        x = (char *) malloc(s);
+        for (size_t i = 0; i < s; i++) {
+            *(x+i) = *(DATA_START + i);
+        }
+    } else {
+        for (size_t i = 0; i < s; i++) {
+            *(DATA_START + i) = *(x+i);
+        }
+    }
+
+    // quick check, see that pepa does not grow in stderr output
+    fprintf(stderr, "pepa: %d\n", pepa++);
+}

--- a/tests/c_unittests/helpers.cpp
+++ b/tests/c_unittests/helpers.cpp
@@ -23,24 +23,25 @@
 
 std::mutex QDR::startup_shutdown_lock;
 
-// disable sanitizer, otherwise writes to memory between global variables are reported as buffer overflows
+// disable sanitizer, otherwise writes to memory in between global variables
+// get reported as buffer overflows
 ATTRIBUTE_NO_SANITIZE_ADDRESS
 void reset_static_data()
 {
-    static char *x;
+    static char *stored_globals;
 
-    size_t s = BSS_END - DATA_START;
+    size_t size = BSS_END - DATA_START;
 
-    // memset is always sanitized, so access memory as chars in a loop
+    // memcpy is always sanitized, so access memory as chars in a loop
 
-    if (x == NULL) {
-        x = (char *) malloc(s);
-        for (size_t i = 0; i < s; i++) {
-            *(x + i) = *(DATA_START + i);
+    if (stored_globals == NULL) {
+        stored_globals = (char *) malloc(size);
+        for (size_t i = 0; i < size; i++) {
+            *(stored_globals + i) = *(DATA_START + i);
         }
     } else {
-        for (size_t i = 0; i < s; i++) {
-            *(DATA_START + i) = *(x + i);
+        for (size_t i = 0; i < size; i++) {
+            *(DATA_START + i) = *(stored_globals + i);
         }
     }
 }

--- a/tests/c_unittests/helpers.hpp
+++ b/tests/c_unittests/helpers.hpp
@@ -34,12 +34,12 @@
 // these extern variables come from glibc
 // https://github.com/ysbaddaden/gc/blob/master/include/config.h
 extern char __data_start[];
-extern char __bss_start;
+extern char __bss_start[];
 extern char _end[];
-#define DATA_START ((char *)&__data_start)
-#define DATA_END &__bss_start
-#define BSS_START &__bss_start
-#define BSS_END ((char *)&_end)
+#define DATA_START ((char *) &__data_start)
+#define DATA_END   ((char *) &__bss_start)
+#define BSS_START  ((char *) &__bss_start)
+#define BSS_END    ((char *) &_end)
 
 void reset_static_data();
 

--- a/tests/c_unittests/helpers.hpp
+++ b/tests/c_unittests/helpers.hpp
@@ -321,6 +321,7 @@ class QDRMinimalEnv
         reset_static_data();
 
         qd_alloc_initialize();
+        qd_entity_cache_initialize();
         qd_log_initialize();
         qd_error_initialize();
     }

--- a/tests/c_unittests/helpers.hpp
+++ b/tests/c_unittests/helpers.hpp
@@ -30,7 +30,6 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
-#include <cstring>
 
 // these extern variables come from glibc
 // https://github.com/ysbaddaden/gc/blob/master/include/config.h

--- a/tests/c_unittests/helpers.hpp
+++ b/tests/c_unittests/helpers.hpp
@@ -30,6 +30,19 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
+#include <cstring>
+
+// these extern variables come from glibc
+// https://github.com/ysbaddaden/gc/blob/master/include/config.h
+extern char __data_start[];
+extern char __bss_start;
+extern char _end[];
+#define DATA_START ((char *)&__data_start)
+#define DATA_END &__bss_start
+#define BSS_START &__bss_start
+#define BSS_END ((char *)&_end)
+
+void reset_static_data();
 
 // assertions without stack traces when running outside doctest
 #ifndef QDR_DOCTEST
@@ -211,6 +224,8 @@ class QDR
     /// prepare the smallest amount of things that qd_dispatch_free needs to be present
     void initialize(const std::string &config_path = "")
     {
+        reset_static_data();
+
         const std::lock_guard<std::mutex> lock(QDR::startup_shutdown_lock);
 
         qd = qd_dispatch(nullptr, false);
@@ -304,6 +319,8 @@ class QDRMinimalEnv
    public:
     QDRMinimalEnv()
     {
+        reset_static_data();
+
         qd_alloc_initialize();
         qd_log_initialize();
         qd_error_initialize();

--- a/tests/c_unittests/helpers.hpp
+++ b/tests/c_unittests/helpers.hpp
@@ -41,6 +41,10 @@ extern char _end[];
 #define BSS_START  ((char *) &__bss_start)
 #define BSS_END    ((char *) &_end)
 
+/// First call copies global variables into a buffer allocated in heap, and
+/// subsequent calls restore the global variables from that buffer.
+///
+/// c.f. https://stackoverflow.com/questions/3704864/in-a-c-program-is-it-possible-to-reset-all-global-variables-to-default-vaues
 void reset_static_data();
 
 // assertions without stack traces when running outside doctest


### PR DESCRIPTION
note to myself: commit [fixup nobody was initializing event_lock before](https://github.com/skupperproject/skupper-router/commit/f0a835d37a05796a5fefe8a04fa7da290d348d1c) contains additional fix