### PR TITLE
Fixes #615 - set QD_LISTENER_BACKLOG to SOMAXCONN

### DIFF
--- a/src/adaptors/adaptor_listener.c
+++ b/src/adaptors/adaptor_listener.c
@@ -27,7 +27,7 @@
 #include <proton/listener.h>
 #include <proton/proactor.h>
 
-#define QD_LISTENER_BACKLOG 50
+#define QD_LISTENER_BACKLOG SOMAXCONN
 
 struct qd_adaptor_listener_t {
 


### PR DESCRIPTION
Thanks, kgiusti for tip about QD_LISTENER_BACKLOG.
BTW - on F36 SOMAXCONN is 4096.
We had this backlog set to 50.

On my box this changed single-client connection rate through the router from 140 to 3400 per second.