### PR TITLE
Use the `global:` env variables in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,12 @@ arch:
   - ppc64le
   - s390x
 env:
-  - PROTON_VERSION=main BUILD_TYPE=RelWithDebInfo RUNTIME_CHECK=asan QD_ENABLE_ASSERTIONS=ON
-  - PROTON_VERSION=main BUILD_TYPE=RelWithDebInfo RUNTIME_CHECK=tsan QD_ENABLE_ASSERTIONS=OFF
+  global:
+    - PROTON_VERSION=main
+    - BUILD_TYPE=RelWithDebInfo
+  jobs:
+    - RUNTIME_CHECK=asan QD_ENABLE_ASSERTIONS=ON
+    - RUNTIME_CHECK=tsan QD_ENABLE_ASSERTIONS=OFF
 
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
     - arch: s390x
   exclude:
     - arch: s390x
-      env: PROTON_VERSION=main BUILD_TYPE=RelWithDebInfo RUNTIME_CHECK=tsan QD_ENABLE_ASSERTIONS=OFF
+      env: RUNTIME_CHECK=tsan QD_ENABLE_ASSERTIONS=OFF
 
 addons:
   apt:


### PR DESCRIPTION
As discovered by @astitcher (https://github.com/apache/qpid-proton/pull/377#issuecomment-1201526630) there is a `travis.yml` option to deduplicate repeated environment variables in jobs specification.

https://docs.travis-ci.com/user/environment-variables/#global-variables