### PR TITLE
Fixes #602: user configurable listener backlog

### DIFF
--- a/python/skupper_router/management/skrouter.json
+++ b/python/skupper_router/management/skrouter.json
@@ -1184,6 +1184,12 @@
                     "default": "0.0.0.0",
                     "create": true
                 },
+                "backlog": {
+                    "description": "Sets the value of the backlog parameter in call to listen(). This controls the maximum queue depth the OS will use for some stages of TCP connection creation.  Value should be integer >= 1, or 'max'. If 'max', the value will be set to the upper limit allowed by the OS.'",
+                    "type": "string",
+                    "default": "max",
+                    "create": true
+                },
                 "port": {
                     "description": "Port number or symbolic service name.  If '0', the router shall assign an ephemeral port to the listener and log the port number with a log of the form 'SERVER (notice) Listening on <host>:<assigned-port> (<listener-name>)'",
                     "type": "string",

--- a/src/adaptors/adaptor_common.h
+++ b/src/adaptors/adaptor_common.h
@@ -46,6 +46,7 @@ struct qd_adaptor_config_t
     char              *address;
     char              *site_id;
     char              *host_port;
+    int                backlog;
 
     //TLS related info
     char              *ssl_profile_name;

--- a/src/adaptors/adaptor_listener.h
+++ b/src/adaptors/adaptor_listener.h
@@ -43,7 +43,8 @@ typedef void (*qd_adaptor_listener_accept_t)(qd_adaptor_listener_t *listener,
 //
 qd_adaptor_listener_t *qd_adaptor_listener(const qd_dispatch_t *qd,
                                            const qd_adaptor_config_t *config,
-                                           qd_log_source_t *log_source);
+                                           qd_log_source_t *log_source,
+                                           int backlog);
 
 // Start listening on the given listener. Note that the on_accept callback may
 // be invoked during this call on another thread.

--- a/src/adaptors/http1/http1_client.c
+++ b/src/adaptors/http1/http1_client.c
@@ -204,7 +204,7 @@ qd_http_listener_t *qd_http1_configure_listener(qd_dispatch_t *qd, qd_http_adapt
         return 0;
     }
 
-    li->adaptor_listener = qd_adaptor_listener(qd, config->adaptor_config, qdr_http1_adaptor->log);
+    li->adaptor_listener = qd_adaptor_listener(qd, config->adaptor_config, qdr_http1_adaptor->log, LISTENER_BACKLOG); // TEMP - replace with backlog from struct in next PR
 
     li->vflow = vflow_start_record(VFLOW_RECORD_LISTENER, 0);
     vflow_set_string(li->vflow, VFLOW_ATTRIBUTE_PROTOCOL,         "http1");

--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -3274,7 +3274,7 @@ qd_http_listener_t *qd_http2_configure_listener(qd_dispatch_t *qd, qd_http_adapt
         return 0;
     }
 
-    li->adaptor_listener = qd_adaptor_listener(qd, config->adaptor_config, http2_adaptor->log_source);
+    li->adaptor_listener = qd_adaptor_listener(qd, config->adaptor_config, http2_adaptor->log_source, 16); // TEMP -- replace with backlog from struct in next PR
 
     li->vflow = vflow_start_record(VFLOW_RECORD_LISTENER, 0);
     vflow_set_string(li->vflow, VFLOW_ATTRIBUTE_PROTOCOL, "http2");

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -1346,7 +1346,7 @@ QD_EXPORT qd_tcp_listener_t *qd_dispatch_configure_tcp_listener(qd_dispatch_t *q
     DEQ_INSERT_TAIL(tcp_adaptor->listeners, li);  // ref_count taken
     sys_mutex_unlock(&tcp_adaptor->listener_lock);
 
-    li->adaptor_listener = qd_adaptor_listener(qd, li->config->adaptor_config, tcp_adaptor->log_source);
+    li->adaptor_listener = qd_adaptor_listener(qd, li->config->adaptor_config, tcp_adaptor->log_source, li->config->adaptor_config->backlog);
     qd_adaptor_listener_listen(li->adaptor_listener, qdr_tcp_connection_ingress, (void*) li);
 
     qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,

--- a/src/adaptors/tcp_adaptor.h
+++ b/src/adaptors/tcp_adaptor.h
@@ -70,6 +70,7 @@ struct qd_tcp_listener_t
     vflow_record_t           *vflow;
     qdr_tcp_stats_t          *tcp_stats;
     qd_adaptor_listener_t    *adaptor_listener;
+    int                       backlog;
 
     // must hold tcp_adaptor->listener_lock during list operations:
     DEQ_LINKS(qd_tcp_listener_t);


### PR DESCRIPTION
Make a new attribute 'backlog' for entity tcpListener.
User can enter integer >= 1, or "max".
Default is "max" -- which means it uses SOMAXCONN.

Invalid value logs error, the uses old value of 50.

I tested setting it to 'max' ,  small integers, and 'foo'.
And then used my connection rate test on it.
Difference in connection rate is very substantial using 'max' vs 5 or 10.
