### PR TITLE
Fixes #655 - Upgrade container image to Proton main (pre 0.38.0)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,7 +32,6 @@ WORKDIR /build
 COPY . .
 ENV PROTON_VERSION=main
 ENV PROTON_SOURCE_URL=${PROTON_SOURCE_URL:-https://github.com/apache/qpid-proton/archive/refs/heads/${PROTON_VERSION}.tar.gz}
-ENV PROTON_SOURCE_URL=${PROTON_SOURCE_URL:-https://archive.apache.org/dist/qpid/proton/${PROTON_VERSION}/qpid-proton-${PROTON_VERSION}.tar.gz}
 ENV LWS_VERSION=v4.3.1
 ENV LWS_SOURCE_URL=${LWS_SOURCE_URL:-https://github.com/warmcat/libwebsockets/archive/refs/tags/${LWS_VERSION}.tar.gz}
 

--- a/Containerfile
+++ b/Containerfile
@@ -30,8 +30,9 @@ RUN microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
 
 WORKDIR /build
 COPY . .
-ENV PROTON_VERSION=0.37.0
-ENV PROTON_SOURCE_URL=${PROTON_SOURCE_URL:-http://archive.apache.org/dist/qpid/proton/${PROTON_VERSION}/qpid-proton-${PROTON_VERSION}.tar.gz}
+ENV PROTON_VERSION=main
+ENV PROTON_SOURCE_URL=${PROTON_SOURCE_URL:-https://github.com/apache/qpid-proton/archive/refs/heads/${PROTON_VERSION}.tar.gz}
+ENV PROTON_SOURCE_URL=${PROTON_SOURCE_URL:-https://archive.apache.org/dist/qpid/proton/${PROTON_VERSION}/qpid-proton-${PROTON_VERSION}.tar.gz}
 ENV LWS_VERSION=v4.3.1
 ENV LWS_SOURCE_URL=${LWS_SOURCE_URL:-https://github.com/warmcat/libwebsockets/archive/refs/tags/${LWS_VERSION}.tar.gz}
 


### PR DESCRIPTION
Replaces the Apache Proton URL with GitHub archive URL.