### PR TITLE
Fixes #224, #667: fix sigterm handling in test clients, update test a…

### DIFF
--- a/tests/system_tests_two_routers.py
+++ b/tests/system_tests_two_routers.py
@@ -1659,9 +1659,7 @@ class StreamingLinkScrubberTest(TestCase):
         senders = [self.popen(cmd, env=env) for x in range(sender_count)]
 
         for tx in senders:
-            out_text, out_error = tx.communicate(timeout=TIMEOUT)
-            if tx.returncode:
-                raise Exception("Sender failed: %s %s" % (out_text, out_error))
+            tx.wait(timeout=TIMEOUT)
 
         # expect: more inter-router links opened.  Should be 12 more, but
         # depending on when the scrubber runs it may be as low as two
@@ -1674,9 +1672,7 @@ class StreamingLinkScrubberTest(TestCase):
             sleep(0.1)
             post_count = len(get_inter_router_links(self.RouterA.listener))
 
-        out_text, out_error = rx.communicate(timeout=TIMEOUT)
-        if rx.returncode:
-            raise Exception("Receiver failed: %s %s" % (out_text, out_error))
+        rx.wait(timeout=TIMEOUT)
 
 
 class TwoRouterExtensionStateTest(TestCase):

--- a/tests/test-receiver.c
+++ b/tests/test-receiver.c
@@ -67,23 +67,16 @@ void debug(const char *format, ...)
     va_start(args, format);
     vprintf(format, args);
     va_end(args);
+    fflush(stdout);
 }
 
 
 static void signal_handler(int signum)
 {
-    signal(SIGINT,  SIG_IGN);
-    signal(SIGQUIT, SIG_IGN);
-
-    switch (signum) {
-    case SIGINT:
-    case SIGQUIT:
-        stop = true;
-        if (proactor) pn_proactor_interrupt(proactor);
-        break;
-    default:
-        break;
-    }
+    signal(signum, SIG_IGN);
+    stop = true;
+    if (proactor)
+        pn_proactor_interrupt(proactor);
 }
 
 
@@ -241,6 +234,7 @@ int main(int argc, char** argv)
 
     signal(SIGQUIT, signal_handler);
     signal(SIGINT,  signal_handler);
+    signal(SIGTERM, signal_handler);
 
     char *host = host_address;
     if (strncmp(host, "amqp://", 7) == 0)

--- a/tests/test-sender.c
+++ b/tests/test-sender.c
@@ -119,6 +119,7 @@ void debug(const char *format, ...)
     va_start(args, format);
     vprintf(format, args);
     va_end(args);
+    fflush(stdout);
 }
 
 
@@ -234,18 +235,10 @@ void generate_message(void)
 
 static void signal_handler(int signum)
 {
-    signal(SIGINT,  SIG_IGN);
-    signal(SIGQUIT, SIG_IGN);
-
-    switch (signum) {
-    case SIGINT:
-    case SIGQUIT:
-        stop = true;
-        if (proactor) pn_proactor_interrupt(proactor);
-        break;
-    default:
-        break;
-    }
+    signal(signum, SIG_IGN);
+    stop = true;
+    if (proactor)
+        pn_proactor_interrupt(proactor);
 }
 
 
@@ -464,6 +457,7 @@ int main(int argc, char** argv)
 
     signal(SIGQUIT, signal_handler);
     signal(SIGINT,  signal_handler);
+    signal(SIGTERM, signal_handler);
 
     char *host = host_address;
     if (strncmp(host, "amqp://", 7) == 0)


### PR DESCRIPTION
…s needed

Fixes some issues in clogger by removing the error check for missing
acks. clogger is a mis-behaving client and is always SIGTERMed by the
tests so no need to track acks.