### PR TITLE
Fixes #339 - Print source file and line number in alloc_pool leak backtraces automatically

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Install Linux build dependencies
         run: |
-          sudo apt update; sudo apt install -y swig libpython3-dev libsasl2-dev libjsoncpp-dev libwebsockets-dev libnghttp2-dev ccache ninja-build pixz libbenchmark-dev
+          sudo apt update; sudo apt install -y libdw-dev swig libpython3-dev libsasl2-dev libjsoncpp-dev libwebsockets-dev libnghttp2-dev ccache ninja-build pixz libbenchmark-dev
 
       - name: Zero ccache stats
         run: ccache -z
@@ -248,7 +248,7 @@ jobs:
 
       - name: Install Linux runtime/test dependencies
         run: |
-          sudo apt update; sudo apt install -y libsasl2-2 libsasl2-modules sasl2-bin libjsoncpp1 libwebsockets15 libbenchmark1 pixz bubblewrap curl ncat gdb elfutils findutils file python3-dbg
+          sudo apt update; sudo apt install -y libdw1 libsasl2-2 libsasl2-modules sasl2-bin libjsoncpp1 libwebsockets15 libbenchmark1 pixz bubblewrap curl ncat gdb elfutils findutils file python3-dbg
 
       - name: Unpack archive
         run: tar -I pixz -xf archive.tar.xz
@@ -436,7 +436,7 @@ jobs:
 
       - name: Install Linux build dependencies
         run: |
-          dnf install -y gcc gcc-c++ cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain swig python3-devel python3-pip make libwebsockets-devel libnghttp2-devel ccache libasan libubsan libtsan
+          dnf install -y gcc gcc-c++ elfutils-devel cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain swig python3-devel python3-pip make libwebsockets-devel libnghttp2-devel ccache libasan libubsan libtsan
 
       - name: Install Python build dependencies
         run: python3 -m pip install setuptools wheel tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ addons:
       # Dispatch requirements
       - libnghttp2-dev
       - libwebsockets-dev
+      # backtrace symbolization
+      - binutils-dev
       # code coverage
       - lcov
       # tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,14 @@ set(CMAKE_ENABLE_EXPORTS TRUE)
 set(C_WARNING_GNU -Wall -Wextra -Werror -Wpedantic -pedantic-errors -Wimplicit-fallthrough=3 -Wno-empty-body -Wno-unused-parameter  -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits)
 set(C_WARNING_Clang -Wall -Wextra -Werror -Wpedantic -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-language-extension-token)
 
+# Additional compiler-specific flags
+#  -gdwarf-aranges to workaround https://sourceware.org/bugzilla/show_bug.cgi?id=22288 (backtrace line printing with libdw and clang)
+set(C_EXTRA_GNU )
+set(C_EXTRA_Clang -gdwarf-aranges)
+
 set(C_WARNING_FLAGS ${C_WARNING_${CMAKE_C_COMPILER_ID}})
-add_compile_options(${C_WARNING_FLAGS})
+set(C_EXTRA_FLAGS ${C_EXTRA_${CMAKE_C_COMPILER_ID}})
+add_compile_options(${C_WARNING_FLAGS} ${C_EXTRA_FLAGS})
 
 # Set default build type. Must use FORCE because project() sets default to ""
 if (NOT CMAKE_BUILD_TYPE)
@@ -124,6 +130,8 @@ find_package(LibWebSockets 4.0.1 REQUIRED)
 ##
 ## Optional dependencies
 ##
+
+find_library(dw_lib dw DOC "libdw used to symbolize QD_MEMORY_DEBUG backtraces")
 
 # google benchmark tests are disabled by default
 OPTION(BUILD_BENCHMARKS "Enable building and running benchmarks with Google Benchmark" OFF)

--- a/include/qpid/dispatch/internal/symbolization.h
+++ b/include/qpid/dispatch/internal/symbolization.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef QPID_DISPATCH_SYMBOLIZATION_H
+#define QPID_DISPATCH_SYMBOLIZATION_H
+
+#include <stdbool.h>
+#include <stdio.h>
+
+typedef struct qd_backtrace_fileline {
+    bool        found;
+    const char *object_filename;
+    const char *object_function;
+    const char *source_filename;
+    int         source_line;
+    int         source_col;
+} qd_backtrace_fileline_t;
+
+/// Call qd_symbolize_finalize when you are done, to free global state.
+/// This also invalidates all const char pointers previously returned.
+void qd_symbolize_finalize();
+
+void qd_print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_symbolization, int i, void *pc);
+qd_backtrace_fileline_t qd_symbolize_backtrace_line(void *target_address);
+
+#endif  // QPID_DISPATCH_SYMBOLIZATION_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,7 +155,16 @@ set(qpid_dispatch_LIBRARIES
   ${Proton_Tls_LIBRARIES}
   ${Python_LIBRARIES}
   ${rt_lib}
+  ${CMAKE_DL_LIBS}
+  ${Python_LIBRARIES}
   )
+
+if (dw_lib)
+  set(qpid_dispatch_SOURCES ${qpid_dispatch_SOURCES} posix/symbolization.c)
+  set(qpid_dispatch_LIBRARIES ${qpid_dispatch_LIBRARIES} ${dw_lib})
+else()
+  set(qpid_dispatch_SOURCES ${qpid_dispatch_SOURCES} posix/symbolization_none.c)
+endif()
 
 if ((DEFINED ASAN_LIBRARY) OR (DEFINED UBSAN_LIBRARY) OR (DEFINED TSAN_LIBRARY))
   set(USING_SANITIZERS TRUE)

--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -37,6 +37,8 @@
 #ifdef QD_MEMORY_DEBUG
 #include "log_private.h"
 
+#include "qpid/dispatch/internal/symbolization.h"
+
 #include <execinfo.h>
 #endif
 
@@ -629,11 +631,12 @@ void qd_alloc_finalize(void)
                     qd_log_formatted_time(&item->timestamp, buf, 100);
                     fprintf(dump_file, "Leak: %s type: %s address: %p\n",
                             buf, desc->type_name, (void *)(&item[1]));
-                    for (size_t i = 0; i < item->backtrace_size; i++)
-                        fprintf(dump_file, "%s\n", strings[i]);
+                    for (int i = 0; i < item->backtrace_size; i++)
+                        qd_print_symbolized_backtrace_line(dump_file, strings[i], i, item->backtrace[i]);
                     fprintf(dump_file, "\n");
                     last_leak = desc->type_name;
                 }
+                qd_symbolize_finalize();
                 free(strings);
 
                 // free the item to prevent ASAN from also reporting this leak.

--- a/src/posix/symbolization.c
+++ b/src/posix/symbolization.c
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define _GNU_SOURCE
+
+#include "qpid/dispatch/internal/symbolization.h"
+
+#include <elfutils/libdw.h>
+#include <elfutils/libdwfl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static struct {
+    bool           libdwlf_inited;
+    Dwfl          *dwfl;            ///< libdwfl handle
+    Dwfl_Callbacks dwfl_callbacks;  ///< struct holding libdfl callbacks
+} state = {0};
+
+bool ensure_libdwfl_intialized()
+{
+    if (!state.libdwlf_inited) {
+        state.dwfl_callbacks.find_elf       = &dwfl_linux_proc_find_elf;
+        state.dwfl_callbacks.find_debuginfo = &dwfl_standard_find_debuginfo;
+        state.dwfl_callbacks.debuginfo_path = NULL;
+        state.dwfl                          = dwfl_begin(&(state.dwfl_callbacks));
+
+        // note all objects in the address space of current process
+        dwfl_report_begin(state.dwfl);
+        int r = dwfl_linux_proc_report(state.dwfl, getpid());
+        dwfl_report_end(state.dwfl, NULL, NULL);
+        if (r < 0) {
+            return false;
+        }
+
+        state.libdwlf_inited = true;
+    }
+
+    return true;
+}
+
+qd_backtrace_fileline_t qd_symbolize_backtrace_line(void *target_address)
+{
+    qd_backtrace_fileline_t result = {0};
+
+    if (!ensure_libdwfl_intialized()) {
+        return result;
+    }
+
+    Dwarf_Addr addr = (Dwarf_Addr) target_address;
+
+    // find the object that contains queried address
+    Dwfl_Module *module = dwfl_addrmodule(state.dwfl, addr);
+    if (module) {
+        const char *module_name = dwfl_module_info(module, 0, 0, 0, 0, 0, 0, 0);
+        if (module_name) {
+            result.object_filename = module_name;
+        }
+        // returns mangled function name, which does not matter if function is written in C
+        const char *sym_name = dwfl_module_addrname(module, addr);
+        if (sym_name) {
+            result.object_function = sym_name;
+        }
+    }
+
+    Dwarf_Addr module_bias = 0;
+    Dwarf_Die *cudie       = dwfl_module_addrdie(module, addr, &module_bias);
+
+    if (cudie == NULL) {
+        // this should not happen if we have debug info,
+        // but if it does fail, then look how bombela/backward-cpp hacks this
+        return result;
+    }
+
+    Dwarf_Line *srcloc = dwarf_getsrc_die(cudie, addr - module_bias);
+
+    if (srcloc) {
+        const char *srcfile = dwarf_linesrc(srcloc, 0, 0);
+        if (srcfile) {
+            result.source_filename = srcfile;
+        }
+        int line = 0;
+        int col  = 0;
+        dwarf_lineno(srcloc, &line);
+        dwarf_linecol(srcloc, &col);
+        result.source_line = line;
+        result.source_col  = col;
+    }
+
+    result.found = true;
+    return result;
+}
+
+void qd_print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_symbolization, int i, void *pc)
+{
+    // attempt to symbolize the address
+    qd_backtrace_fileline_t res = qd_symbolize_backtrace_line(pc);
+    if (res.found) {
+        fprintf(dump_file,
+                "#%d %s %s:%d\n\tin %s\n",
+                i,
+                res.object_function ? res.object_function : "(? ?)",
+                res.source_filename ? res.source_filename : "(null)",
+                res.source_line,
+                res.object_filename ? res.object_filename : "(null)");
+        return;
+    }
+
+    // symbolization did not succeed, print the uninspiring backtrace_symbols output as fallback
+    fprintf(dump_file, "   %s\n", fallback_symbolization);
+}
+
+void qd_symbolize_finalize()
+{
+    if (state.libdwlf_inited) {
+        dwfl_end(state.dwfl);
+    }
+    state.libdwlf_inited = false;
+}

--- a/src/posix/symbolization_none.c
+++ b/src/posix/symbolization_none.c
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "qpid/dispatch/internal/symbolization.h"
+
+qd_backtrace_fileline_t qd_symbolize_backtrace_line(void *addr)
+{
+    qd_backtrace_fileline_t result = {0};
+    return result;
+}
+
+void qd_print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_symbolization, int i, void *pc)
+{
+    // symbolization did not succeed, print the uninspiring backtrace_symbols output as fallback
+    fprintf(dump_file, "   %s\n", fallback_symbolization);
+}
+
+void qd_symbolize_finalize() {}

--- a/tests/c_unittests/CMakeLists.txt
+++ b/tests/c_unittests/CMakeLists.txt
@@ -22,6 +22,10 @@
 # -Wno-literal-suffix allows compiling string literals such as "[C%"PRIu64"]" as C++
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD_FLAGS} -fno-inline -fno-builtin -fno-stack-protector -Wno-literal-suffix")
 
+if(NOT dw_lib)
+    add_compile_definitions("QD_SKIP_LIBDW_TESTS")
+endif()
+
 add_library(static_accessors_server_c SHARED
         static_accessors_server_c.c)
 target_compile_options(static_accessors_server_c PRIVATE -fvisibility=hidden)
@@ -39,8 +43,8 @@ add_executable(c_unittests
         test_listener_startup.cpp
         test_router_startup.cpp
         test_server.cpp
-        test_terminus.cpp)
-target_link_libraries(c_unittests cpp-stub pthread skupper-router static_accessors_server_c)
+        test_terminus.cpp test_alloc_pool.cpp)
+target_link_libraries(c_unittests cpp-stub pthread skupper-router static_accessors_server_c ${bfd_lib})
 # http_common.h includes "delivery.h"
 target_include_directories(c_unittests PRIVATE ${CMAKE_SOURCE_DIR}/src/router_core)
 

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "qdr_doctest.hpp"
+
+extern "C" {
+#include "qpid/dispatch/internal/symbolization.h"
+}
+
+#include <execinfo.h>
+#include <stdlib.h>
+
+#include <cstdio>
+
+namespace test_backtrace
+{
+
+const int STACK_DEPTH = 10;
+
+struct item {
+    void *backtrace[STACK_DEPTH];
+    int   backtrace_size;
+};
+
+extern "C" {
+
+const int probe_line = __LINE__;
+void      probe() {}
+
+void b_stores_backtrace(item &item)
+{
+    item.backtrace_size = backtrace(item.backtrace, STACK_DEPTH);
+}
+
+void a_calls_b(item &item)
+{
+    b_stores_backtrace(item);
+}
+}
+
+TEST_CASE("qd_symbolize_backtrace_line")
+{
+#ifdef QD_SKIP_LIBDW_TESTS
+    return;
+#endif
+
+    const qd_backtrace_fileline_t &res = qd_symbolize_backtrace_line((void *) probe);
+    CHECK(res.found);
+    if (!res.found) {
+        qd_symbolize_finalize();
+        return;
+    }
+    CHECK(res.source_filename == __FILE__);
+    CHECK(res.object_function == "probe");
+    CHECK(std::abs(probe_line - res.source_line) <= 3);  // require reasonable precision
+    qd_symbolize_finalize();
+}
+
+TEST_CASE("qd_print_symbolized_backtrace_line")
+{
+    item it;
+    a_calls_b(it);
+
+    char **strings = backtrace_symbols(it.backtrace, it.backtrace_size);
+
+    for (int i = 0; i < it.backtrace_size; i++) {
+        qd_print_symbolized_backtrace_line(stdout, strings[i], i, it.backtrace[i]);
+    }
+    printf("\n");
+    qd_symbolize_finalize();
+    free(strings);
+}
+
+}  // namespace test_backtrace


### PR DESCRIPTION
* Alternative to https://github.com/skupperproject/skupper-router/pull/340

When this works, the stacktrace looks like

```
69: #0 __interceptor_backtrace.part.0 ../../../../libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4277
69: 	in /usr/lib64/libasan.so.8.0.0
69: #1 b_stores_backtrace /home/jdanek/repos/skupper-router/tests/c_unittests/test_alloc_pool.cpp:53
69: 	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/tests/c_unittests/c_unittests
69: #2 _ZN14test_backtraceL19DOCTEST_ANON_FUNC_4Ev /home/jdanek/repos/skupper-router/tests/c_unittests/test_alloc_pool.cpp:82
69: 	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/tests/c_unittests/c_unittests
69: #3 _ZN7doctest7Context3runEv /home/jdanek/repos/skupper-router/tests/c_unittests/doctest.h:6728
69: 	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/tests/c_unittests/c_unittests
69: #4 main /home/jdanek/repos/skupper-router/tests/c_unittests/c_unittests_main.cpp:78
69: 	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/tests/c_unittests/c_unittests
69: #5 __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:74
69: 	in /usr/lib64/libc.so.6
69: #6 __libc_start_main@@GLIBC_2.34 ../csu/libc-start.c:128
69: 	in /usr/lib64/libc.so.6
69: #7 _start (null):0
69: 	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/tests/c_unittests/c_unittests
```

or (see in the original PR)

```
Leak: 2022-08-07 19:11:50.284766 +0200 type: qd_log_entry_t address: 0x61d000056f10
#0 __interceptor_backtrace.part.0 ../../../../libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4277
	in /usr/lib64/libasan.so.8.0.0
#1 qd_alloc /home/jdanek/repos/skupper-router/src/alloc_pool.c:369
	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/router/skrouterd
#2 qd_vlog_impl /home/jdanek/repos/skupper-router/src/log.c:64
	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/router/skrouterd
#3 qd_log_impl /home/jdanek/repos/skupper-router/src/log.c:465
	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/router/skrouterd
#4 qdr_modules_init /home/jdanek/repos/skupper-router/src/router_core/router_core_thread.c:135
	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/router/skrouterd
#5 qdr_core /home/jdanek/repos/skupper-router/src/router_core/router_core.c:67
	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/router/skrouterd
#6 qd_router_setup_late /home/jdanek/repos/skupper-router/src/router_node.c:2058
	in /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-asan/router/skrouterd
#7 ffi_call_unix64 ../src/x86/unix64.S:108
	in /usr/lib64/libffi.so.8.1.0
#8 ffi_call_int.lto_priv.0 ../src/x86/ffi64.c:674
	in /usr/lib64/libffi.so.8.1.0
#9 _ctypes_callproc /usr/src/debug/python3.11-3.11.0~b3-1.fc36.x86_64/Include/object.h:601
	in /usr/lib64/python3.11/lib-dynload/_ctypes.cpython-311-x86_64-linux-gnu.so
```