### PR TITLE
ISSUE-771: add streaming link lifecycle debug logging

### DIFF
--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -1653,6 +1653,8 @@ qdr_link_t *qdr_connection_new_streaming_link_CT(qdr_core_t *core, qdr_connectio
             qdr_add_connection_ref(&core->streaming_connections, conn);
             conn->has_streaming_links = true;
         }
+        qd_log(core->log, QD_LOG_DEBUG, "[C%" PRIu64 "][L%" PRIu64 "] Created new outgoing streaming link %s",
+               conn->identity, out_link->identity, out_link->name);
     }
     return out_link;
 }

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -94,6 +94,8 @@ static inline qdr_link_t *get_outgoing_streaming_link(qdr_core_t *core, qdr_conn
     if (out_link) {
         DEQ_REMOVE_HEAD_N(STREAMING_POOL, conn->streaming_link_pool);
         out_link->in_streaming_pool = false;
+        qd_log(core->log, QD_LOG_DEBUG, "[C%" PRIu64 "][L%" PRIu64 "] Taking streaming link %s from free pool",
+               conn->identity, out_link->identity, out_link->name);
     } else {
         // no free links - create a new one
         out_link = qdr_connection_new_streaming_link_CT(core, conn);


### PR DESCRIPTION
This doesn't fix the issue but should help us understand the state of the streaming links when the test does fail