### PR TITLE
Issue #767: Temporarily disable leaking TCP adapter benchmarks tests

### DIFF
--- a/tests/c_benchmarks/bm_tcp_adapter.cpp
+++ b/tests/c_benchmarks/bm_tcp_adapter.cpp
@@ -214,6 +214,7 @@ class LatencyMeasure
 /// In addition, all sends are of the same (tiny) size
 static void DISABLED_BM_TCPEchoServerLatencyWithoutQDR(benchmark::State &state)
 {
+    return;  // disabled
     EchoServerThread est;
 
     LatencyMeasure lm;
@@ -287,11 +288,12 @@ class DispatchRouterSubprocessTcpLatencyTest
 
 static void DISABLED_BM_TCPEchoServerLatency1QDRThread(benchmark::State &state)
 {
+    return;  // disabled
     auto est                        = make_unique<EchoServerThread>();
     unsigned short tcpConnectorPort = est->port();
     unsigned short tcpListenerPort  = findFreePort();
 
-    std::string       configName    = "DISABLED_BM_TCPEchoServerLatency1QDRThread";
+    std::string       configName    = "BM_TCPEchoServerLatency1QDRThread";
     std::stringstream router_config = oneRouterTcpConfig(tcpConnectorPort, tcpListenerPort);
     writeRouterConfig(configName, router_config);
 
@@ -318,6 +320,7 @@ BENCHMARK(DISABLED_BM_TCPEchoServerLatency1QDRThread)->Unit(benchmark::kMillisec
 
 static void DISABLED_BM_TCPEchoServerLatency1QDRSubprocess(benchmark::State &state)
 {
+    return;  // disabled
     EchoServerThread est;
     unsigned short tcpConnectorPort = est.port();
     unsigned short tcpListenerPort  = findFreePort();
@@ -338,6 +341,7 @@ BENCHMARK(DISABLED_BM_TCPEchoServerLatency1QDRSubprocess)->Unit(benchmark::kMill
 
 static void DISABLED_BM_TCPEchoServerLatency2QDRSubprocess(benchmark::State &state)
 {
+    return;  // disabled
     EchoServerThread est;
 
     unsigned short listener_2    = findFreePort();

--- a/tests/c_benchmarks/bm_tcp_adapter.cpp
+++ b/tests/c_benchmarks/bm_tcp_adapter.cpp
@@ -212,7 +212,7 @@ class LatencyMeasure
 /// There is only one request in flight at all times, so this is the
 ///  lowest conceivable latency at the most ideal condition
 /// In addition, all sends are of the same (tiny) size
-static void BM_TCPEchoServerLatencyWithoutQDR(benchmark::State &state)
+static void DISABLED_BM_TCPEchoServerLatencyWithoutQDR(benchmark::State &state)
 {
     EchoServerThread est;
 
@@ -220,7 +220,7 @@ static void BM_TCPEchoServerLatencyWithoutQDR(benchmark::State &state)
     lm.latencyMeasureLoop(state, est.port());
 }
 
-BENCHMARK(BM_TCPEchoServerLatencyWithoutQDR)->Unit(benchmark::kMillisecond);
+BENCHMARK(DISABLED_BM_TCPEchoServerLatencyWithoutQDR)->Unit(benchmark::kMillisecond);
 
 class DispatchRouterThreadTCPLatencyTest
 {
@@ -285,13 +285,13 @@ class DispatchRouterSubprocessTcpLatencyTest
     }
 };
 
-static void BM_TCPEchoServerLatency1QDRThread(benchmark::State &state)
+static void DISABLED_BM_TCPEchoServerLatency1QDRThread(benchmark::State &state)
 {
     auto est                        = make_unique<EchoServerThread>();
     unsigned short tcpConnectorPort = est->port();
     unsigned short tcpListenerPort  = findFreePort();
 
-    std::string configName          = "BM_TCPEchoServerLatency1QDRThread";
+    std::string       configName    = "DISABLED_BM_TCPEchoServerLatency1QDRThread";
     std::stringstream router_config = oneRouterTcpConfig(tcpConnectorPort, tcpListenerPort);
     writeRouterConfig(configName, router_config);
 
@@ -314,15 +314,15 @@ static void BM_TCPEchoServerLatency1QDRThread(benchmark::State &state)
     est.reset();
 }
 
-BENCHMARK(BM_TCPEchoServerLatency1QDRThread)->Unit(benchmark::kMillisecond);
+BENCHMARK(DISABLED_BM_TCPEchoServerLatency1QDRThread)->Unit(benchmark::kMillisecond);
 
-static void BM_TCPEchoServerLatency1QDRSubprocess(benchmark::State &state)
+static void DISABLED_BM_TCPEchoServerLatency1QDRSubprocess(benchmark::State &state)
 {
     EchoServerThread est;
     unsigned short tcpConnectorPort = est.port();
     unsigned short tcpListenerPort  = findFreePort();
 
-    std::string configName          = "BM_TCPEchoServerLatency1QDRSubprocess.conf";
+    std::string       configName    = "DISABLED_BM_TCPEchoServerLatency1QDRSubprocess.conf";
     std::stringstream router_config = oneRouterTcpConfig(tcpConnectorPort, tcpListenerPort);
     writeRouterConfig(configName, router_config);
 
@@ -334,9 +334,9 @@ static void BM_TCPEchoServerLatency1QDRSubprocess(benchmark::State &state)
     }
 }
 
-BENCHMARK(BM_TCPEchoServerLatency1QDRSubprocess)->Unit(benchmark::kMillisecond);
+BENCHMARK(DISABLED_BM_TCPEchoServerLatency1QDRSubprocess)->Unit(benchmark::kMillisecond);
 
-static void BM_TCPEchoServerLatency2QDRSubprocess(benchmark::State &state)
+static void DISABLED_BM_TCPEchoServerLatency2QDRSubprocess(benchmark::State &state)
 {
     EchoServerThread est;
 
@@ -360,4 +360,4 @@ static void BM_TCPEchoServerLatency2QDRSubprocess(benchmark::State &state)
     }
 }
 
-BENCHMARK(BM_TCPEchoServerLatency2QDRSubprocess)->Unit(benchmark::kMillisecond);
+BENCHMARK(DISABLED_BM_TCPEchoServerLatency2QDRSubprocess)->Unit(benchmark::kMillisecond);


### PR DESCRIPTION
Follows https://github.com/google/benchmark/blob/main/docs/user_guide.md#disabling-benchmarks