### PR TITLE
ISSUE #754: work around possible Q2 egress stall

### DIFF
--- a/src/adaptors/http1/http1_client.c
+++ b/src/adaptors/http1/http1_client.c
@@ -1594,6 +1594,10 @@ uint64_t qdr_http1_client_core_link_deliver(qdr_http1_adaptor_t    *adaptor,
             qdr_delivery_set_context(delivery, hreq);
             qdr_delivery_incref(delivery, "HTTP1 client referencing response delivery");
             DEQ_INSERT_TAIL(hreq->responses, rmsg);
+
+            // workaround for Q2 stall, ISSUE #754/#758
+            qd_message_Q2_holdoff_disable(msg);
+
             qd_log(qdr_http1_adaptor->log, QD_LOG_TRACE,
                    "[C%"PRIu64"][L%"PRIu64"] HTTP received response for msg-id=%"PRIu64,
                    hconn->conn_id, hconn->out_link_id, hreq->base.msg_id);

--- a/src/adaptors/http1/http1_server.c
+++ b/src/adaptors/http1/http1_server.c
@@ -1652,6 +1652,9 @@ uint64_t qdr_http1_server_core_link_deliver(qdr_http1_adaptor_t    *adaptor,
             hreq->request_dlv = delivery;
             qdr_delivery_set_context(delivery, (void*) hreq);
             qdr_delivery_incref(delivery, "HTTP1 server referencing request delivery");
+
+            // workaround for Q2 stall, ISSUE #754/#758
+            qd_message_Q2_holdoff_disable(msg);
             break;
         }
 

--- a/tests/system_tests_http1_adaptor.py
+++ b/tests/system_tests_http1_adaptor.py
@@ -841,6 +841,10 @@ class Http1AdaptorQ2Standalone(TestCase):
         """
         Trigger Q2 backpressure against the HTTP client.
         """
+        # Q2 is disabled on egress http1 messages to prevent an
+        # irrecoverable stall - see Issue #754
+        self.skipTest("ISSUE #754 workaround causes this test to fail")
+
         router, listener_port, server_port = self.create_router("Q2Router1")
 
         # create a listener socket to act as the server service
@@ -921,6 +925,10 @@ class Http1AdaptorQ2Standalone(TestCase):
         """
         Trigger Q2 backpressure against the HTTP server.
         """
+        # Q2 is disabled on egress http1 messages to prevent an
+        # irrecoverable stall - see Issue #754
+        self.skipTest("ISSUE #754 workaround causes this test to fail")
+
         router, listener_port, server_port = self.create_router("Q2Router2")
 
         small_get_req = b'GET / HTTP/1.1\r\nContent-Length: 0\r\n\r\n'


### PR DESCRIPTION
See ISSUE #754 (and #758). These failures appear to be cause by a stall in the egress side. The test logs show that the egress HTTP/1 message is unable to completely receive a full stream body data section (incomplete). Debug logging shows that the egress message has Q2 in blocking state, which means the remaining octets of the stream body data cannot be received until Q2 is unblocked. Q2 cannot be unblocked since that can only occur when the entire stream body data has arrived and sent out the raw connection.

This work-around disables Q2 on egress which should prevent the stall. Unfortuantely I cannot reliably reproduce this stall locally so time will tell if this workaround actually alleviates the stall.