### PR TITLE
Undefine `DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING` to reduce amount of magic

### DIFF
--- a/tests/c_unittests/qdr_doctest.hpp
+++ b/tests/c_unittests/qdr_doctest.hpp
@@ -21,8 +21,7 @@
 #define QDR_DOCTEST
 
 // this must be defined globally
-// https://github.com/onqtam/doctest/blob/master/doc/markdown/configuration.md#doctest_config_treat_char_star_as_string
-#define DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+// https://github.com/onqtam/doctest/blob/master/doc/markdown/configuration.md
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 #include "doctest.h"

--- a/tests/c_unittests/test_alloc_pool.cpp
+++ b/tests/c_unittests/test_alloc_pool.cpp
@@ -27,6 +27,8 @@ extern "C" {
 #include <stdlib.h>
 
 #include <cstdio>
+#include <string>
+using std::string_literals::operator""s;
 
 namespace test_backtrace
 {
@@ -66,8 +68,8 @@ TEST_CASE("qd_symbolize_backtrace_line")
         qd_symbolize_finalize();
         return;
     }
-    CHECK(res.source_filename == __FILE__);
-    CHECK(res.object_function == "probe");
+    CHECK(res.source_filename == std::string{__FILE__});
+    CHECK(res.object_function == "probe"s);
     CHECK(std::abs(probe_line - res.source_line) <= 3);  // require reasonable precision
     qd_symbolize_finalize();
 }

--- a/tests/c_unittests/test_connection_manager_static.cpp
+++ b/tests/c_unittests/test_connection_manager_static.cpp
@@ -33,7 +33,9 @@ extern "C" {
 #include <sys/mman.h>
 
 #include <set>
+#include <string>
 #include <thread>
+using std::string_literals::operator""s;
 
 extern "C" {
 QD_EXPORT qd_config_ssl_profile_t *qd_dispatch_configure_ssl_profile(qd_dispatch_t *qd, qd_entity_t *entity);
@@ -50,7 +52,7 @@ static void check_password(qd_dispatch_t *qd, const char *password, const char *
     qd_config_ssl_profile_t *profile = qd_dispatch_configure_ssl_profile(qd, entity);
     if (expect_success) {
         REQUIRE(profile != nullptr);
-        CHECK(profile->ssl_password == expected);
+        CHECK(profile->ssl_password == std::string{expected});
         qd_connection_manager_delete_ssl_profile(qd, profile);
     } else {
         REQUIRE(profile == nullptr);
@@ -97,7 +99,7 @@ TEST_CASE("qd_dispatch_configure_ssl_profile")
                             return "";
                         }
 
-                        CHECK(name == "some_env_variable");
+                        CHECK(name == "some_env_variable"s);
                         return "some_password";
                     });
                 check_password(qd, "env:some_env_variable", "some_password");
@@ -112,8 +114,8 @@ TEST_CASE("qd_dispatch_configure_ssl_profile")
                     Stub s{};
                     s.set(
                         fopen, +[](const char *name, const char *mode) {
-                            CHECK(name == "/some/file");
-                            CHECK(mode == "r");
+                            CHECK(name == "/some/file"s);
+                            CHECK(mode == "r"s);
 
                             // create fake file in memory and return it
                             int fd           = memfd_create("tmpfile", 0);

--- a/tests/c_unittests/test_server.cpp
+++ b/tests/c_unittests/test_server.cpp
@@ -24,6 +24,9 @@
 
 #include <stdint.h>
 
+#include <string>
+using std::string_literals::operator""s;
+
 extern "C" {
 double testonly_normalize_memory_size(const uint64_t bytes, const char **suffix);
 }
@@ -33,7 +36,7 @@ static void test_normalize_memory_size(uint64_t bytes, double expected_value, co
     const char *suffix = NULL;
     double value       = testonly_normalize_memory_size(bytes, &suffix);
     CHECK(value == expected_value);
-    CHECK(suffix == expected_suffix);
+    CHECK(suffix == std::string{expected_suffix});
 }
 
 TEST_CASE("normalize_memory_size")

--- a/tests/c_unittests/test_terminus.cpp
+++ b/tests/c_unittests/test_terminus.cpp
@@ -18,7 +18,11 @@
  */
 
 #include "qdr_doctest.hpp"
+
 #include "cpp_stub.h"
+
+#include <string>
+using std::string_literals::operator""s;
 
 extern "C" {
 #include "qpid/dispatch/router_core.h"
@@ -51,19 +55,19 @@ TEST_CASE("test_safe_snprintf") {
         SUBCASE("") {
             len = safe_snprintf(output, LEN + 10, TEST_MESSAGE);
             CHECK(LEN == len);
-            CHECK(output == TEST_MESSAGE);
+            CHECK(output == std::string{TEST_MESSAGE});
         }
 
         SUBCASE("") {
             len = safe_snprintf(output, LEN + 1, TEST_MESSAGE);
             CHECK(LEN == len);
-            CHECK(output == TEST_MESSAGE);
+            CHECK(output == std::string{TEST_MESSAGE});
         }
 
         SUBCASE("") {
             len = safe_snprintf(output, LEN, TEST_MESSAGE);
             CHECK(LEN - 1 == len);
-            CHECK(output == "somethin");
+            CHECK(output == "somethin"s);
         }
 
         SUBCASE("") {
@@ -105,7 +109,7 @@ TEST_CASE("test_qdr_terminus_format") {
         SUBCASE("") {
             qdr_terminus_format(NULL, output, &size);
 
-            CHECK(output == "{}");
+            CHECK(output == "{}"s);
             CHECK(size == 1);
         }
     }


### PR DESCRIPTION
There is a feature in doctest allowing to compare `char *`s with `==`, turning it into `strcmp`.
This is very practical on one hand, but on the other hand it is too magical.
Also, the feature is broken in 2.4.9 release of doctest, showing it's probably rarely enabled.

## New way of working

```
#include <string>
using std::string_literals::operator""s;
```

Then use `"string"s` literals and casts to `std::string{s}` on one side of `==` to get the C++ `strcmp` equivalent instead of comparing pointers.