### PR TITLE
Fixes #634: Revert "Run Fedora GHA test jobs with `-j12` threads again" and use `-j6` instead

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -531,7 +531,7 @@ jobs:
           
           threads=12
           if [[ "${{ matrix.runtimeCheck }}" == "tsan" ]]; then
-            threads=2
+            threads=6
           fi
 
           ctest --timeout 1200 -V --output-junit=Testing/Test.xml --output-on-failure --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j${threads} ${{env.RouterCTestExtraArgs}}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -530,6 +530,9 @@ jobs:
           ulimit -c unlimited
           
           threads=12
+          if [[ "${{ matrix.runtimeCheck }}" == "tsan" ]]; then
+            threads=2
+          fi
 
           ctest --timeout 1200 -V --output-junit=Testing/Test.xml --output-on-failure --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j${threads} ${{env.RouterCTestExtraArgs}}
 


### PR DESCRIPTION
Reverts and modifies skupperproject/skupper-router#563