### PR TITLE
Use Fedora 37 in GitHub Actions CI builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -307,7 +307,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         container: ['fedora']
-        containerTag: ['36']
+        containerTag: ['37']
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
         protonGitRef:
@@ -348,7 +348,7 @@ jobs:
           # coverage
           - os: ubuntu-20.04
             container: 'fedora'
-            containerTag: 36
+            containerTag: 37
             buildType: Coverage
             runtimeCheck: OFF
             protonGitRef: 0.38.0


### PR DESCRIPTION
Fedora 37 is to come out 1st of November 2022, https://fedorapeople.org/groups/schedule/f-37/f-37-key-tasks.html