### PR TITLE
Issue #773: Refactor TCP/HTTP configuration management

### DIFF
--- a/python/skupper_router_internal/management/agent.py
+++ b/python/skupper_router_internal/management/agent.py
@@ -506,7 +506,10 @@ class AllocatorEntity(EntityAdapter):
 
 class HttpListenerEntity(EntityAdapter):
     def create(self):
-        return self._qd.qd_dispatch_configure_http_listener(self._dispatch, self)
+        http_listener = self._qd.qd_dispatch_configure_http_listener(self._dispatch, self)
+        if http_listener is None:
+            raise ValidationError("Invalid httpListener configuration: see logs for details.")
+        return http_listener
 
     def _identifier(self):
         return _host_port_name_identifier(self)
@@ -521,6 +524,8 @@ class HttpListenerEntity(EntityAdapter):
 class TcpListenerEntity(EntityAdapter):
     def create(self):
         config_listener = self._qd.qd_dispatch_configure_tcp_listener(self._dispatch, self)
+        if config_listener is None:
+            raise ValidationError("Invalid tcpListener configuration: see logs for details.")
         return config_listener
 
     def _identifier(self):
@@ -536,6 +541,8 @@ class TcpListenerEntity(EntityAdapter):
 class TcpConnectorEntity(EntityAdapter):
     def create(self):
         config_connector = self._qd.qd_dispatch_configure_tcp_connector(self._dispatch, self)
+        if config_connector is None:
+            raise ValidationError("Invalid tcpConnector configuration: see logs for details.")
         return config_connector
 
     def _identifier(self):
@@ -550,7 +557,10 @@ class TcpConnectorEntity(EntityAdapter):
 
 class HttpConnectorEntity(EntityAdapter):
     def create(self):
-        return self._qd.qd_dispatch_configure_http_connector(self._dispatch, self)
+        http_connector = self._qd.qd_dispatch_configure_http_connector(self._dispatch, self)
+        if http_connector is None:
+            raise ValidationError("Invalid httpConnector configuration: see logs for details.")
+        return http_connector
 
     def _identifier(self):
         return _host_port_name_identifier(self)

--- a/src/adaptors/adaptor_common.c
+++ b/src/adaptors/adaptor_common.c
@@ -46,7 +46,7 @@ void qd_free_adaptor_config(qd_adaptor_config_t *config)
 
 #define CHECK() if (qd_error_code()) goto error
 
-qd_error_t qd_load_adaptor_config(qd_dispatch_t *qd, qd_adaptor_config_t *config, qd_entity_t* entity, qd_log_source_t *log_source)
+qd_error_t qd_load_adaptor_config(qd_adaptor_config_t *config, qd_entity_t *entity)
 {
     qd_error_clear();
     config->name    = qd_entity_opt_string(entity, "name", 0);                 CHECK();
@@ -66,20 +66,6 @@ qd_error_t qd_load_adaptor_config(qd_dispatch_t *qd, qd_adaptor_config_t *config
     int hplen = strlen(config->host) + strlen(config->port) + 2;
     config->host_port = malloc(hplen);
     snprintf(config->host_port, hplen, "%s:%s", config->host, config->port);
-
-    if (config->ssl_profile_name) {
-        qd_connection_manager_t *cm = qd_dispatch_connection_manager(qd);
-        assert(cm);
-        qd_config_ssl_profile_t *config_ssl_profile = qd_find_ssl_profile(cm, config->ssl_profile_name);
-
-        if(!config_ssl_profile) {
-            //
-            // The sslProfile was not found, we are going to terminate the router.
-            //
-            qd_log(log_source, QD_LOG_CRITICAL, "sslProfile %s could not be found", config->ssl_profile_name);
-            exit(1);
-        }
-    }
 
     return QD_ERROR_NONE;
 

--- a/src/adaptors/adaptor_common.h
+++ b/src/adaptors/adaptor_common.h
@@ -62,7 +62,7 @@ struct qd_adaptor_config_t
 
 ALLOC_DECLARE(qd_adaptor_config_t);
 
-qd_error_t qd_load_adaptor_config(qd_dispatch_t *qd, qd_adaptor_config_t *config, qd_entity_t* entity, qd_log_source_t *log_source);
+qd_error_t qd_load_adaptor_config(qd_adaptor_config_t *config, qd_entity_t *entity);
 void qd_free_adaptor_config(qd_adaptor_config_t *config);
 
 /**

--- a/src/adaptors/http1/http1_client.c
+++ b/src/adaptors/http1/http1_client.c
@@ -196,15 +196,9 @@ static void _handle_listener_accept(qd_adaptor_listener_t *adaptor_listener, pn_
 // Note that this runs on the Management Agent thread, which may be running concurrently with the
 // I/O and timer threads.
 //
-qd_http_listener_t *qd_http1_configure_listener(qd_dispatch_t *qd, qd_http_adaptor_config_t *config, qd_entity_t *entity)
+qd_http_listener_t *qd_http1_configure_listener(qd_http_listener_t *li, qd_dispatch_t *qd, qd_entity_t *entity)
 {
-    qd_http_listener_t *li = qd_http_listener(qd->server, config);
-    if (!li) {
-        qd_log(qdr_http1_adaptor->log, QD_LOG_ERROR, "Unable to create http listener: no memory");
-        return 0;
-    }
-
-    li->adaptor_listener = qd_adaptor_listener(qd, config->adaptor_config, qdr_http1_adaptor->log);
+    li->adaptor_listener = qd_adaptor_listener(qd, li->config->adaptor_config, qdr_http1_adaptor->log);
 
     li->vflow = vflow_start_record(VFLOW_RECORD_LISTENER, 0);
     vflow_set_string(li->vflow, VFLOW_ATTRIBUTE_PROTOCOL,         "http1");
@@ -221,9 +215,9 @@ qd_http_listener_t *qd_http1_configure_listener(qd_dispatch_t *qd, qd_http_adapt
            li->config->adaptor_config->host_port, li->config->adaptor_config->backlog);
     // Note: the proactor may execute _handle_listener_accept on another thread during this call
     qd_adaptor_listener_listen(li->adaptor_listener, _handle_listener_accept, (void *) li);
+
     return li;
 }
-
 
 // Management Agent API - Delete
 //

--- a/src/adaptors/http1/http1_server.c
+++ b/src/adaptors/http1/http1_server.c
@@ -143,7 +143,7 @@ static void _send_request_message(_server_request_t *hreq);
 // An HttpConnector has been created.  Create an qdr_http_connection_t and a
 // qdr_connection_t for it.
 //
-static qdr_http1_connection_t *_create_server_connection(qd_http_connector_t *ctor, qd_dispatch_t *qd)
+static qdr_http1_connection_t *_create_server_connection(qd_http_connector_t *connector, qd_dispatch_t *qd)
 {
     qdr_http1_connection_t *hconn = new_qdr_http1_connection_t();
     assert(hconn);
@@ -157,16 +157,17 @@ static qdr_http1_connection_t *_create_server_connection(qd_http_connector_t *ct
     hconn->handler_context.handler = &_handle_connection_events;
     hconn->handler_context.context = hconn;
     sys_atomic_init(&hconn->q2_restart, 0);
-    hconn->cfg.host      = qd_strdup(ctor->config->adaptor_config->host);
-    hconn->cfg.port      = qd_strdup(ctor->config->adaptor_config->port);
-    hconn->cfg.address   = qd_strdup(ctor->config->adaptor_config->address);
-    hconn->cfg.site      = ctor->config->adaptor_config->site_id ? qd_strdup(ctor->config->adaptor_config->site_id) : 0;
-    hconn->cfg.host_port = qd_strdup(ctor->config->adaptor_config->host_port);
-    hconn->server.connector = ctor;
-    ctor->ctx = (void*)hconn;
-    hconn->cfg.event_channel = ctor->config->event_channel;
-    hconn->cfg.aggregation   = ctor->config->aggregation;
-    hconn->cfg.host_override = ctor->config->host_override ? qd_strdup(ctor->config->host_override) : 0;
+    hconn->cfg.host    = qd_strdup(connector->config->adaptor_config->host);
+    hconn->cfg.port    = qd_strdup(connector->config->adaptor_config->port);
+    hconn->cfg.address = qd_strdup(connector->config->adaptor_config->address);
+    hconn->cfg.site =
+        connector->config->adaptor_config->site_id ? qd_strdup(connector->config->adaptor_config->site_id) : 0;
+    hconn->cfg.host_port     = qd_strdup(connector->config->adaptor_config->host_port);
+    hconn->server.connector  = connector;
+    connector->ctx           = (void *) hconn;
+    hconn->cfg.event_channel = connector->config->event_channel;
+    hconn->cfg.aggregation   = connector->config->aggregation;
+    hconn->cfg.host_override = connector->config->host_override ? qd_strdup(connector->config->host_override) : 0;
 
     // for initiating a connection to the server
     hconn->server.reconnect_timer = qd_timer(qdr_http1_adaptor->core->qd, _do_reconnect, hconn);
@@ -217,20 +218,21 @@ static qdr_http1_connection_t *_create_server_connection(qd_http_connector_t *ct
 //
 // Note that this runs on the Management Agent thread, which may be running concurrently with the
 // I/O and timer threads.
-qd_http_connector_t *qd_http1_configure_connector(qd_http_connector_t *c, qd_dispatch_t *qd, qd_entity_t *entity)
+qd_http_connector_t *qd_http1_configure_connector(qd_http_connector_t *connector, qd_dispatch_t *qd,
+                                                  qd_entity_t *entity)
 {
-    qdr_http1_connection_t *hconn = _create_server_connection(c, qd);
+    qdr_http1_connection_t *hconn = _create_server_connection(connector, qd);
     assert(hconn);
 
     qd_log(qdr_http1_adaptor->log, QD_LOG_DEBUG, "[C%" PRIu64 "] Initiating connection to HTTP server %s",
            hconn->conn_id, hconn->cfg.host_port);
 
-    c->vflow = vflow_start_record(VFLOW_RECORD_CONNECTOR, 0);
-    vflow_set_string(c->vflow, VFLOW_ATTRIBUTE_PROTOCOL, "http1");
-    vflow_set_string(c->vflow, VFLOW_ATTRIBUTE_NAME, c->config->adaptor_config->name);
-    vflow_set_string(c->vflow, VFLOW_ATTRIBUTE_DESTINATION_HOST, c->config->adaptor_config->host);
-    vflow_set_string(c->vflow, VFLOW_ATTRIBUTE_DESTINATION_PORT, c->config->adaptor_config->port);
-    vflow_set_string(c->vflow, VFLOW_ATTRIBUTE_VAN_ADDRESS, c->config->adaptor_config->address);
+    connector->vflow = vflow_start_record(VFLOW_RECORD_CONNECTOR, 0);
+    vflow_set_string(connector->vflow, VFLOW_ATTRIBUTE_PROTOCOL, "http1");
+    vflow_set_string(connector->vflow, VFLOW_ATTRIBUTE_NAME, connector->config->adaptor_config->name);
+    vflow_set_string(connector->vflow, VFLOW_ATTRIBUTE_DESTINATION_HOST, connector->config->adaptor_config->host);
+    vflow_set_string(connector->vflow, VFLOW_ATTRIBUTE_DESTINATION_PORT, connector->config->adaptor_config->port);
+    vflow_set_string(connector->vflow, VFLOW_ATTRIBUTE_VAN_ADDRESS, connector->config->adaptor_config->address);
 
     // lock out the core activation thread.  Up until this point the core
     // thread cannot activate the qdr_connection_t since the
@@ -240,32 +242,34 @@ qd_http_connector_t *qd_http1_configure_connector(qd_http_connector_t *c, qd_dis
     // setup.
     sys_mutex_lock(&qdr_http1_adaptor->lock);
     DEQ_INSERT_TAIL(qdr_http1_adaptor->connections, hconn);
-    DEQ_INSERT_TAIL(qdr_http1_adaptor->connectors, c);
+    DEQ_INSERT_TAIL(qdr_http1_adaptor->connectors, connector);
     qdr_connection_set_context(hconn->qdr_conn, hconn);
     qd_timer_schedule(hconn->server.reconnect_timer, 0);
     sys_mutex_unlock(&qdr_http1_adaptor->lock);
     // setup complete - core thread can activate the connection
 
-    return c;
+    return connector;
 }
 
 // Management Agent API - Delete
 //
 // Note that this runs on the Management Agent thread, which may be running concurrently with the
 // I/O and timer threads.
-void qd_http1_delete_connector(qd_dispatch_t *ignored, qd_http_connector_t *ct)
+void qd_http1_delete_connector(qd_dispatch_t *ignored, qd_http_connector_t *connector)
 {
-    if (ct) {
-        qd_log(qdr_http1_adaptor->log, QD_LOG_INFO, "Deleted HttpConnector for %s, %s:%s", ct->config->adaptor_config->address, ct->config->adaptor_config->host, ct->config->adaptor_config->port);
+    if (connector) {
+        qd_log(qdr_http1_adaptor->log, QD_LOG_INFO, "Deleted HttpConnector for %s, %s:%s",
+               connector->config->adaptor_config->address, connector->config->adaptor_config->host,
+               connector->config->adaptor_config->port);
 
         sys_mutex_lock(&qdr_http1_adaptor->lock);
-        DEQ_REMOVE(qdr_http1_adaptor->connectors, ct);
-        qdr_http1_connection_t *hconn = (qdr_http1_connection_t*) ct->ctx;
+        DEQ_REMOVE(qdr_http1_adaptor->connectors, connector);
+        qdr_http1_connection_t *hconn    = (qdr_http1_connection_t *) connector->ctx;
         qdr_connection_t *qdr_conn = 0;
         if (hconn) {
             hconn->admin_status = QD_CONN_ADMIN_DELETED;
             hconn->server.connector = 0;
-            ct->ctx = 0;
+            connector->ctx          = 0;
             qdr_conn = hconn->qdr_conn;
         }
         sys_mutex_unlock(&qdr_http1_adaptor->lock);
@@ -273,7 +277,7 @@ void qd_http1_delete_connector(qd_dispatch_t *ignored, qd_http_connector_t *ct)
         if (qdr_conn)
             // this will cause the core thread to activate the connection and call qdr_http1_server_core_conn_close()
             qdr_core_close_connection(qdr_conn);
-        qd_http_connector_decref(ct);
+        qd_http_connector_decref(connector);
     }
 }
 

--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -2941,15 +2941,9 @@ void qd_http2_delete_listener(qd_dispatch_t *qd, qd_http_listener_t *li)
 /**
  * Create listener via Management request
  */
-qd_http_listener_t *qd_http2_configure_listener(qd_dispatch_t *qd, qd_http_adaptor_config_t *config, qd_entity_t *entity)
+qd_http_listener_t *qd_http2_configure_listener(qd_http_listener_t *li, qd_dispatch_t *qd, qd_entity_t *entity)
 {
-    qd_http_listener_t *li = qd_http_listener(qd->server, config);
-    if (!li) {
-        qd_log(http2_adaptor->log_source, QD_LOG_ERROR, "Unable to create http listener: no memory");
-        return 0;
-    }
-
-    li->adaptor_listener = qd_adaptor_listener(qd, config->adaptor_config, http2_adaptor->log_source);
+    li->adaptor_listener = qd_adaptor_listener(qd, li->config->adaptor_config, http2_adaptor->log_source);
 
     li->vflow = vflow_start_record(VFLOW_RECORD_LISTENER, 0);
     vflow_set_string(li->vflow, VFLOW_ATTRIBUTE_PROTOCOL, "http2");
@@ -2969,16 +2963,8 @@ qd_http_listener_t *qd_http2_configure_listener(qd_dispatch_t *qd, qd_http_adapt
     return li;
 }
 
-
-qd_http_connector_t *qd_http2_configure_connector(qd_dispatch_t *qd, qd_http_adaptor_config_t *config, qd_entity_t *entity)
+qd_http_connector_t *qd_http2_configure_connector(qd_http_connector_t *c, qd_dispatch_t *qd, qd_entity_t *entity)
 {
-    qd_http_connector_t *c = qd_http_connector(qd->server);
-    if (!c) {
-        qd_log(http2_adaptor->log_source, QD_LOG_ERROR, "Unable to create http connector: no memory");
-        return 0;
-    }
-    c->config = config;
-    DEQ_ITEM_INIT(c);
     DEQ_INSERT_TAIL(http2_adaptor->connectors, c);
     qdr_http_connection_egress(c);
     return c;

--- a/src/adaptors/http_common.h
+++ b/src/adaptors/http_common.h
@@ -65,7 +65,7 @@ struct qd_http_listener_t {
 };
 DEQ_DECLARE(qd_http_listener_t, qd_http_listener_list_t);
 
-qd_http_listener_t *qd_http_listener(qd_server_t *server, qd_http_adaptor_config_t *config);
+qd_http_listener_t *qd_http_listener(qd_server_t *server);
 void                qd_http_listener_decref(qd_http_listener_t *li);
 
 typedef struct qd_http_connector_t qd_http_connector_t;
@@ -113,22 +113,18 @@ void qd_http_record_request(qdr_core_t *core, const char * method, uint32_t stat
                             uint64_t bytes_in, uint64_t bytes_out, uint64_t latency);
 char *qd_get_host_from_host_port(const char *host_port);
 
-qd_http_adaptor_config_t *qd_load_http_adaptor_config(qd_dispatch_t *qd, qd_entity_t *entity,
-                                                      qd_log_source_t *log_source);
-void                      qd_free_http_adaptor_config(qd_http_adaptor_config_t *config);
-
 //
 // These functions are defined in their respective HTTP adaptors:
 //
 
-qd_http_listener_t *qd_http1_configure_listener(qd_dispatch_t *, qd_http_adaptor_config_t *, qd_entity_t *);
-qd_http_listener_t *qd_http2_configure_listener(qd_dispatch_t *, qd_http_adaptor_config_t *, qd_entity_t *);
+qd_http_listener_t *qd_http1_configure_listener(qd_http_listener_t *, qd_dispatch_t *, qd_entity_t *);
+qd_http_listener_t *qd_http2_configure_listener(qd_http_listener_t *, qd_dispatch_t *, qd_entity_t *);
 
 void qd_http1_delete_listener(qd_dispatch_t *, qd_http_listener_t *);
 void qd_http2_delete_listener(qd_dispatch_t *, qd_http_listener_t *);
 
-qd_http_connector_t *qd_http1_configure_connector(qd_dispatch_t *, qd_http_adaptor_config_t *, qd_entity_t *);
-qd_http_connector_t *qd_http2_configure_connector(qd_dispatch_t *, qd_http_adaptor_config_t *, qd_entity_t *);
+qd_http_connector_t *qd_http1_configure_connector(qd_http_connector_t *, qd_dispatch_t *, qd_entity_t *);
+qd_http_connector_t *qd_http2_configure_connector(qd_http_connector_t *, qd_dispatch_t *, qd_entity_t *);
 
 void qd_http1_delete_connector(qd_dispatch_t *, qd_http_connector_t *);
 void qd_http2_delete_connector(qd_dispatch_t *, qd_http_connector_t *);

--- a/src/adaptors/tcp/tcp_adaptor.h
+++ b/src/adaptors/tcp/tcp_adaptor.h
@@ -101,8 +101,6 @@ void qdra_tcp_connection_get_CT(qdr_core_t          *core,
                                 qdr_query_t         *query,
                                 const char          *qdr_tcp_connection_columns[]);
 
-void qd_free_tcp_adaptor_config(qd_tcp_adaptor_config_t *config, qd_log_source_t  *log_source);
-qd_error_t qd_load_tcp_adaptor_config(qd_dispatch_t *qd, qd_tcp_adaptor_config_t *config, qd_entity_t* entity);
 #define QDR_TCP_CONNECTION_COLUMN_COUNT 10
 extern const char *qdr_tcp_connection_columns[QDR_TCP_CONNECTION_COLUMN_COUNT + 1];
 

--- a/tests/c_unittests/test_http_listener_connector.cpp
+++ b/tests/c_unittests/test_http_listener_connector.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Configure and start HTTP_ADAPTOR listener")
 
             // check logging
             std::string       logging = css.str();
-            const std::string unable  = R"EOS(HTTP_ADAPTOR (error) Unable to load config information)EOS";
+            const std::string unable  = R"EOS(HTTP_ADAPTOR (error) Unable to configure a new httpListener)EOS";
             CHECK_MESSAGE(logging.find(unable) != std::string::npos, unable, " not found in ", logging);
         }
 
@@ -150,7 +150,7 @@ TEST_CASE("Configure and start HTTP connector")
 
         // check logging
         std::string       logging = css.str();
-        const std::string unable  = R"EOS(HTTP_ADAPTOR (error) Unable to load config information)EOS";
+        const std::string unable  = R"EOS(HTTP_ADAPTOR (error) Unable to configure a new httpConnector)EOS";
         CHECK_MESSAGE(logging.find(unable) != std::string::npos, unable, " not found in ", logging);
     }
 


### PR DESCRIPTION
This does not solve ISSUE #773 (TLS domain sharing), but it cleans up a number of bugs in the way the TCP and HTTP adaptors load and validate configuration.

Also modifies the HTTP configuration implementation to be consistent with the current TCP implementation.