### PR TITLE
Issue #800: Enable `-Wstrict-prototypes`, `-Wold-style-definition` GCC flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,12 @@ set(CMAKE_ENABLE_EXPORTS TRUE)
 
 
 # Set warning compile flags
-set(C_WARNING_GNU -Wall -Wextra -Werror -Wpedantic -pedantic-errors -Wimplicit-fallthrough=3 -Wno-empty-body -Wno-unused-parameter  -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits)
-set(C_WARNING_Clang -Wall -Wextra -Werror -Wpedantic -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-language-extension-token)
+set(C_WARNING_GNU -Wall -Wextra -Werror -Wpedantic -pedantic-errors
+        $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes> $<$<COMPILE_LANGUAGE:C>:-Wold-style-definition> -Wimplicit-fallthrough=3
+        -Wno-empty-body -Wno-unused-parameter  -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits)
+set(C_WARNING_Clang -Wall -Wextra -Werror -Wpedantic
+        -Wstrict-prototypes -Wold-style-definition
+        -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-language-extension-token)
 
 # Additional compiler-specific flags
 #  -gdwarf-aranges to workaround https://sourceware.org/bugzilla/show_bug.cgi?id=22288 (backtrace line printing with libdw and clang)

--- a/src/posix/symbolization_none.c
+++ b/src/posix/symbolization_none.c
@@ -31,4 +31,4 @@ void qd_print_symbolized_backtrace_line(FILE *dump_file, const char *fallback_sy
     fprintf(dump_file, "   %s\n", fallback_symbolization);
 }
 
-void qd_symbolize_finalize() {}
+void qd_symbolize_finalize(void) {}

--- a/tests/adaptor_buffer_test.c
+++ b/tests/adaptor_buffer_test.c
@@ -23,7 +23,7 @@
 
 void qd_log_initialize(void);
 void qd_log_finalize(void);
-void qd_error_initialize();
+void qd_error_initialize(void);
 void qd_router_id_finalize(void);
 
 static char *test_qd_adaptor_buffer(void *context)
@@ -330,7 +330,7 @@ static char *test_qd_adaptor_copy_qd_buffers_to_adaptor_buffers(void *context)
     return 0;
 }
 
-int adaptor_buffer_tests()
+int adaptor_buffer_tests(void)
 {
     int   result     = 0;
     char *test_group = "adaptor_buffer_tests";


### PR DESCRIPTION
To be merged after https://github.com/skupperproject/skupper-router/pull/803, https://github.com/skupperproject/skupper-router/pull/813 is merged.