### PR TITLE
Fixes #820: Split  qd_raw_connection_drain_read_write_buffers() in ad…

### DIFF
--- a/src/adaptors/adaptor_common.h
+++ b/src/adaptors/adaptor_common.h
@@ -88,7 +88,20 @@ int qd_raw_connection_write_buffers(pn_raw_connection_t *pn_raw_conn, qd_adaptor
 char *qd_raw_conn_get_address(pn_raw_connection_t *pn_raw_conn);
 
 /**
+ * Drains write buffers held by proton raw connection.
+ * @param raw_conn - The pn_raw_connection_t to which the write buffers were granted.
+ */
+int qd_raw_connection_drain_write_buffers(pn_raw_connection_t *pn_raw_conn);
+
+/**
+ * Drains read buffers held by proton raw connection.
+ * @param raw_conn - The pn_raw_connection_t to which the read buffers were granted.
+ */
+int qd_raw_connection_drain_read_buffers(pn_raw_connection_t *pn_raw_conn);
+
+/**
  * Drains read and write buffers held by proton raw connection.
+ * @param raw_conn - The pn_raw_connection_t to which the read and write buffers were granted
  */
 int qd_raw_connection_drain_read_write_buffers(pn_raw_connection_t *pn_raw_conn);
 


### PR DESCRIPTION
…aptor_common.c into qd_raw_connection_drain_write_buffers() and qd_raw_connection_drain_read_buffers()