### PR TITLE
Fixes #816: Removed the call to drain read buffers from the handler o…

### DIFF
--- a/src/adaptors/tcp/tcp_adaptor.c
+++ b/src/adaptors/tcp/tcp_adaptor.c
@@ -1037,10 +1037,8 @@ static void handle_connection_event(pn_event_t *e, qd_server_t *qd_server, void 
         conn->q2_blocked = false;
         UNLOCK(&conn->activation_lock);
         handle_incoming(conn, "PNRC_CLOSED_READ");
-        int num_drained_read_buffers = qd_raw_connection_drain_read_buffers(conn->pn_raw_conn);
-        qd_log(log, QD_LOG_DEBUG,
-               "[C%" PRIu64 "][L%" PRIu64 "] PN_RAW_CONNECTION_CLOSED_READ %s, drained %i read bufers", conn->conn_id,
-               conn->incoming_link_id, qdr_tcp_connection_role_name(conn), num_drained_read_buffers);
+        qd_log(log, QD_LOG_DEBUG, "[C%" PRIu64 "][L%" PRIu64 "] PN_RAW_CONNECTION_CLOSED_READ %s", conn->conn_id,
+               conn->incoming_link_id, qdr_tcp_connection_role_name(conn));
         break;
     }
     case PN_RAW_CONNECTION_CLOSED_WRITE: {


### PR DESCRIPTION
…f PN_RAW_CONNECTION_CLOSED_READ. The drain buffers in the PN_RAW_CONNECTION_DISCONNECTED seems to be enough to drain read buffers