### PR TITLE
ISSUE-676: http1 client refactor to centralize raw I/O processing

### DIFF
--- a/src/adaptors/http1/http1_private.h
+++ b/src/adaptors/http1/http1_private.h
@@ -191,6 +191,7 @@ void qdr_http1_free_written_buffers(qdr_http1_connection_t *hconn);
 void qdr_http1_enqueue_buffer_list(qdr_http1_out_data_list_t *fifo, qd_buffer_list_t *blist, uintmax_t octets);
 void qdr_http1_enqueue_stream_data(qdr_http1_out_data_list_t *fifo, qd_message_stream_data_t *stream_data);
 uint64_t qdr_http1_write_out_data(qdr_http1_connection_t *hconn, qdr_http1_out_data_list_t *fifo);
+uint64_t  qdr_http1_get_out_buffers(qdr_http1_out_data_list_t *fifo, qd_adaptor_buffer_list_t *abuf_list, size_t limit);
 void      qdr_http1_out_data_cleanup(qdr_http1_out_data_list_t *out_data);
 uintmax_t qdr_http1_get_read_buffers(qdr_http1_connection_t *hconn,
                                      qd_buffer_list_t *blist);
@@ -200,6 +201,13 @@ void qdr_http1_connection_free(qdr_http1_connection_t *hconn);
 
 void qdr_http1_request_base_cleanup(qdr_http1_request_base_t *hreq);
 void qdr_http1_q2_unblocked_handler(const qd_alloc_safe_ptr_t context);
+
+typedef uint64_t qdr_http1_get_output_data_cb_t(void *context, qd_adaptor_buffer_list_t *a_bufs, size_t limit);
+bool             qdr_http1_do_raw_io(pn_raw_connection_t            *raw_conn,
+                                     qdr_http1_get_output_data_cb_t *get_output_cb,
+                                     void                           *get_output_context,
+                                     qd_adaptor_buffer_list_t       *input_data,
+                                     uint64_t                       *input_octets);
 
 // http1_client.c protocol adaptor callbacks
 //


### PR DESCRIPTION
Moves all raw connection I/O to a single phase in the connection event handler. This is intended to simplify the client-side I/O processing in preparation of adding TLS support.