### PR TITLE
ISSUE-676: HTTP/1 Client-facing TLS support

### DIFF
--- a/src/adaptors/adaptor_buffer.c
+++ b/src/adaptors/adaptor_buffer.c
@@ -70,7 +70,9 @@ qd_adaptor_buffer_t *qd_get_adaptor_buffer_from_pn_raw_buffer(const pn_raw_buffe
 {
     assert(pn_raw_buffer);
     qd_adaptor_buffer_t *adaptor_buffer = (qd_adaptor_buffer_t *) pn_raw_buffer->context;
-    qd_adaptor_buffer_insert(adaptor_buffer, pn_raw_buffer->size);
+    // set the buffer->size: don't call qd_adaptor_buffer_insert() which increments the size!
+    adaptor_buffer->size = pn_raw_buffer->size;
+    assert(adaptor_buffer->size <= QD_ADAPTOR_MAX_BUFFER_SIZE);
     return adaptor_buffer;
 }
 

--- a/src/adaptors/http1/http1_server.c
+++ b/src/adaptors/http1/http1_server.c
@@ -597,6 +597,8 @@ static void _handle_connection_events(pn_event_t *e, qd_server_t *qd_server, voi
         _process_request(hreq);
         hreq = 0;  // _process_request *may* free hreq, do not trust this pointer!
 
+        qd_raw_connection_drain_read_write_buffers(hconn->raw_conn);
+
         //
         // Try to reconnect to the server. Leave the links intact so pending
         // requests are not aborted.  If we fail to reconnect after

--- a/tests/system_tests_http1_over_tcp.py
+++ b/tests/system_tests_http1_over_tcp.py
@@ -45,27 +45,26 @@ class Http1OverTcpOneRouterTest(Http1OneRouterTestBase,
         #      V         V
         #  <clients>  <servers>
 
-        cls.routers = []
         super(Http1OverTcpOneRouterTest, cls).router('INT.A', 'standalone',
-                                                     [('tcpConnector', {'port': cls.http_server11_port,
-                                                                        'host': '127.0.0.1',
+                                                     [('tcpConnector', {'port': cls.server11_port,
+                                                                        'host': cls.server11_host,
                                                                         'address': 'testServer11'}),
-                                                      ('tcpConnector', {'port': cls.http_server10_port,
-                                                                        'host': '127.0.0.1',
+                                                      ('tcpConnector', {'port': cls.server10_port,
+                                                                        'host': cls.server10_host,
                                                                         'address': 'testServer10'}),
-                                                      ('tcpListener', {'port': cls.http_listener11_port,
-                                                                       'host': '127.0.0.1',
+                                                      ('tcpListener', {'port': cls.listener11_port,
+                                                                       'host': cls.listener11_host,
                                                                        'address': 'testServer11'}),
-                                                      ('tcpListener', {'port': cls.http_listener10_port,
-                                                                       'host': '127.0.0.1',
+                                                      ('tcpListener', {'port': cls.listener10_port,
+                                                                       'host': cls.listener10_host,
                                                                        'address': 'testServer10'})
                                                       ])
 
         cls.INT_A = cls.routers[0]
         cls.INT_A.listener = cls.INT_A.addresses[0]
 
-        cls.http11_server = TestServer.new_server(cls.http_server11_port, cls.http_listener11_port, cls.TESTS_11)
-        cls.http10_server = TestServer.new_server(cls.http_server10_port, cls.http_listener10_port, cls.TESTS_10,
+        cls.http11_server = TestServer.new_server(server_port=cls.server11_port, client_port=cls.listener11_port, tests=cls.TESTS_11)
+        cls.http10_server = TestServer.new_server(server_port=cls.server10_port, client_port=cls.listener10_port, tests=cls.TESTS_10,
                                                   handler_cls=RequestHandler10)
         cls.INT_A.wait_connectors()
         wait_tcp_listeners_up(cls.INT_A.listener)
@@ -112,9 +111,9 @@ class Http1OverTcpEdge2EdgeTest(Http1Edge2EdgeTestBase, CommonHttp1Edge2EdgeTest
         super(Http1OverTcpEdge2EdgeTest, cls).\
             router('EA1', 'edge', [('connector', {'name': 'uplink', 'role': 'edge',
                                                   'port': cls.INTA_edge1_port}),
-                                   ('tcpListener', {'port': cls.http_listener11_port,
+                                   ('tcpListener', {'port': cls.listener11_port,
                                                     'address': 'testServer11'}),
-                                   ('tcpListener', {'port': cls.http_listener10_port,
+                                   ('tcpListener', {'port': cls.listener10_port,
                                                     'address': 'testServer10'})
                                    ])
         cls.EA1 = cls.routers[1]
@@ -123,11 +122,11 @@ class Http1OverTcpEdge2EdgeTest(Http1Edge2EdgeTestBase, CommonHttp1Edge2EdgeTest
         super(Http1OverTcpEdge2EdgeTest, cls).\
             router('EA2', 'edge', [('connector', {'name': 'uplink', 'role': 'edge',
                                                   'port': cls.INTA_edge2_port}),
-                                   ('tcpConnector', {'port': cls.http_server11_port,
-                                                     'host': '127.0.0.1',
+                                   ('tcpConnector', {'port': cls.server11_port,
+                                                     'host': cls.server11_host,
                                                      'address': 'testServer11'}),
-                                   ('tcpConnector', {'port': cls.http_server10_port,
-                                                     'host': '127.0.0.1',
+                                   ('tcpConnector', {'port': cls.server10_port,
+                                                     'host': cls.server10_host,
                                                      'address': 'testServer10'})
                                    ])
         cls.EA2 = cls.routers[-1]


### PR DESCRIPTION
- Refactor http1_client.c I/O to allow TLS integration
- Add a new workloop-oriented TLS API
- Modify HTTP/1 tests to allow TLS configuration