### PR TITLE
Fixes #874: Import copy_file from distutils.file_util instead of from…

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -20,7 +20,7 @@
 
 from setuptools import setup
 from setuptools.command.build_py import build_py
-from setuptools.command.build_ext import copy_file
+from distutils.file_util import copy_file
 from os.path import join
 from os import environ
 


### PR DESCRIPTION
… setuptools.command.build_ext. This fixes the python error