### PR TITLE
Fixes #885 - Improve vFlow tests; fix issues with cross-network access to router vFlow agents

### DIFF
--- a/src/router_core/modules/edge_addr_tracking/edge_addr_tracking.c
+++ b/src/router_core/modules/edge_addr_tracking/edge_addr_tracking.c
@@ -205,6 +205,13 @@ static bool qdrc_can_send_address(qdr_address_t *addr, qdr_connection_t *in_conn
         return true;
     }
 
+    //
+    // If there is a propagated in-process destination for this address, sending is allowed.
+    //
+    if (addr->propagate_local) {
+        return true;
+    }
+
     return false;
 }
 
@@ -341,7 +348,7 @@ static void on_link_event(void *context, qdrc_event_t event, qdr_link_t *link)
         {
             qdr_addr_tracking_module_context_t *mc = (qdr_addr_tracking_module_context_t*) context;
             qdr_address_t *addr = link->owning_addr;
-            if (addr && qdr_address_is_mobile_CT(addr) && DEQ_SIZE(addr->subscriptions) == 0 && link->link_direction == QD_INCOMING) {
+            if (addr && qdr_address_is_mobile_CT(addr) && (DEQ_SIZE(addr->subscriptions) == 0 || addr->propagate_local) && link->link_direction == QD_INCOMING) {
                 qdr_addr_endpoint_state_t *endpoint_state = qdrc_get_endpoint_state_for_connection(mc->endpoint_state_list, link->conn);
                 // Fix for DISPATCH-1492. Remove the assert(endpoint_state); and add an if condition check for endpoint_state
                 // We will not prevent regular endpoints from connecting to the edge listener for now.

--- a/src/router_core/modules/mobile_sync/mobile.c
+++ b/src/router_core/modules/mobile_sync/mobile.c
@@ -918,6 +918,12 @@ static void qcm_mobile_sync_on_router_advanced_CT(qdrm_mobile_sync_t *msync, qdr
 }
 
 
+static uint32_t local_dest_count(qdr_address_t *addr)
+{
+    return DEQ_SIZE(addr->rlinks) - addr->proxy_rlink_count + (addr->propagate_local ? 1 : 0);
+}
+
+
 static void qcm_mobile_sync_on_addr_event_CT(void          *context,
                                              qdrc_event_t   event_type,
                                              qdr_address_t *addr)
@@ -926,13 +932,13 @@ static void qcm_mobile_sync_on_addr_event_CT(void          *context,
 
     switch (event_type) {
     case QDRC_EVENT_ADDR_ADDED_LOCAL_DEST:
-        if (DEQ_SIZE(addr->rlinks) - addr->proxy_rlink_count == 1) {
+        if (local_dest_count(addr) == 1) {
             qcm_mobile_sync_on_became_local_dest_CT(msync, addr);
         }
         break;
         
     case QDRC_EVENT_ADDR_REMOVED_LOCAL_DEST:
-        if (DEQ_SIZE(addr->rlinks) - addr->proxy_rlink_count == 0) {
+        if (local_dest_count(addr) == 0) {
             qcm_mobile_sync_on_no_longer_local_dest_CT(msync, addr);
         }
         break;

--- a/src/router_core/route_tables.c
+++ b/src/router_core/route_tables.c
@@ -696,8 +696,10 @@ static void qdr_subscribe_CT(qdr_core_t *core, qdr_action_t *action, bool discar
                 qd_hash_insert(core->addr_hash, address->iterator, addr, &addr->hash_handle);
                 DEQ_ITEM_INIT(addr);
                 DEQ_INSERT_TAIL(core->addrs, addr);
-            } else if (aclass == QD_ITER_HASH_PREFIX_MOBILE && sub->propagate) {
-                qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_ADDED_LOCAL_DEST, addr);
+                if (aclass == QD_ITER_HASH_PREFIX_MOBILE && sub->propagate) {
+                    addr->propagate_local = true;
+                    qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_ADDED_LOCAL_DEST, addr);
+                }
             }
         }
         if (addr) {

--- a/tests/system_tests_vflow.py
+++ b/tests/system_tests_vflow.py
@@ -22,10 +22,12 @@ from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from proton import Message
 
+# Attribute constants from the VanFlow specification
 IDENTITY    = 1
 START_TIME  = 3
 RECORD_TYPE = 0
 
+# Record identifier constants from the VanFlow specification
 RT_ROUTER = 1
 
 class RouterTest(TestCase):

--- a/tests/system_tests_vflow.py
+++ b/tests/system_tests_vflow.py
@@ -30,6 +30,7 @@ RECORD_TYPE = 0
 # Record identifier constants from the VanFlow specification
 RT_ROUTER = 1
 
+
 class RouterTest(TestCase):
 
     inter_router_port = None


### PR DESCRIPTION
There were two issues with propagated indication of the presence of an in-process destination for an address.  One affected interior-interior forwarding and the other affected edge-interior forwarding.  This caused FLUSH commands from a remote vFlow collector to not arrive at the intended event source.

There were a number of defects in the existing vFLow tests that prevented the detection of the above issue.  The tests are also fixed in this PR.