### PR TITLE
Fixes #894 - Override shortDescription in TestCase to hide docstring in test logs

### DIFF
--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -1290,6 +1290,12 @@ class TestCase(unittest.TestCase, Tester):  # pylint: disable=too-many-public-me
         Tester.teardown(self)
         super().tearDown()
 
+    def shortDescription(self) -> Optional[str]:
+        """Returns None to disable showing first line of docstring in unittest logs.
+
+        https://stackoverflow.com/questions/12962772/how-to-stop-python-unittest-from-printing-test-docstring"""
+        return None
+
     def assert_fair(self, seq):
         avg = sum(seq) / len(seq)
         for i in seq:


### PR DESCRIPTION
    ctest -VV -R system_tests_autolinks

## Before

test 16
    Start 16: system_tests_autolinks

16: Test command: /home/jdanek/.cache/pypoetry/virtualenvs/skupper-router-7_an9NB3-py3.11/bin/python "/home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-clang/tests/run.py" "-m" "unittest" "-v" "system_tests_autolinks"
16: Working Directory: /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-clang/tests
16: Test timeout computed to be: 600
16: test_auto_link_reattach (system_tests_autolinks.AutoLinkRetryTest.test_auto_link_reattach) ... ok
16: test_01_autolink_attach (system_tests_autolinks.AutolinkTest.test_01_autolink_attach)
16: Create the route-container connection and verify that the appropriate links are attached. ... ok
16: test_03_autolink_sender (system_tests_autolinks.AutolinkTest.test_03_autolink_sender)
16: Create a route-container connection and a normal sender.  Ensure that messages sent on the sender ... ok

[...]
```

## After

```
test 16
    Start 16: system_tests_autolinks

16: Test command: /home/jdanek/.cache/pypoetry/virtualenvs/skupper-router-7_an9NB3-py3.11/bin/python "/home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-clang/tests/run.py" "-m" "unittest" "-v" "system_tests_autolinks"
16: Working Directory: /home/jdanek/repos/skupper-router/cmake-build-relwithdebinfo-clang/tests
16: Test timeout computed to be: 600
16: test_auto_link_reattach (system_tests_autolinks.AutoLinkRetryTest.test_auto_link_reattach) ... ok
16: test_01_autolink_attach (system_tests_autolinks.AutolinkTest.test_01_autolink_attach) ... ok
16: test_03_autolink_sender (system_tests_autolinks.AutolinkTest.test_03_autolink_sender) ... ok
16: test_06_manage_autolinks (system_tests_autolinks.AutolinkTest.test_06_manage_autolinks) ... ok

[...]
```
