### PR TITLE
Fixes #941 - ignore CI errors due to failure to purge successful test logs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -281,6 +281,7 @@ jobs:
 
       - name: Delete logs from passing tests
         if: ${{ failure() }}
+        continue-on-error: true
         run: python3 ${{github.workspace}}/skupper-router/scripts/gha_purge_successful_test_logs.py --build-dir=${{env.RouterBuildDir}} --no-dry-run
 
       - name: Upload log files (if any tests failed)
@@ -577,6 +578,7 @@ jobs:
 
       - name: Delete logs from passing tests
         if: ${{ failure() }}
+        continue-on-error: true
         run: python3 ${{github.workspace}}/skupper-router/scripts/gha_purge_successful_test_logs.py --build-dir=${{env.RouterBuildDir}} --no-dry-run
 
       - name: Upload log files (if any tests failed)


### PR DESCRIPTION
Resolves issues such as

```
python3: can't open file '/home/runner/work/skupper-router/skupper-router/skupper-router/scripts/gha_purge_successful_test_logs.py': [Errno 2] No such file or directory
```

that happen when something failed early in machine preparation, so that we don't even have skupper-router sources available.

Since GHA results viewer expands the last failing step, it would bring attention to this result-processing step, while the actual job failure is at the top of the job page.

See what this looks like in action at https://github.com/jiridanek/skupper-router/actions/runs/4106925849/jobs/7085823735, which is a job run that deliberately fails to install dependencies to demonstrate the failure behavior. The "Delete logs from passing tests" is marked as success, even though it failed, and it is not expanded automatically, instead the apt failure is expanded.

Fixes #941