### PR TITLE
Always run `clang-format` against diff with upstream/main branch, even in user forks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -611,8 +611,11 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
+      - name: Fetch upstream main reference
+        run: |
+          git remote add upstream https://github.com/skupperproject/skupper-router.git
+          git fetch -a upstream
 
       - name: Install clang-format
         run: python3 -m pip install clang-format
@@ -620,7 +623,7 @@ jobs:
       - name: Perform clang-format check
         run: |
           set -o pipefail
-          scripts/git-clang-format origin/main --diff | tee clang-format.patch
+          scripts/git-clang-format upstream/main --diff | tee clang-format.patch
 
       - name: Upload the proposed patch to Artifacts
         if: ${{ failure() }}


### PR DESCRIPTION
Previously, when running GHA in a user's project on a branch, clang-format would compare that branch with user's main branch. When that copy of the main branch is behind the changed branch, there will be some random diff in C code due to this, and clang-format will start reporting issues:

![image](https://user-images.githubusercontent.com/442720/220969612-4b51604e-9d85-4ff7-a716-c5313e5ddb4e.png)

The solution seems to be to ensure that clang-format is always doing a comparison with the upstream main (at skupperproject/skupper-router). Then, the very same branch passes green.

![image](https://user-images.githubusercontent.com/442720/220969900-59bf2d69-835f-48d2-9e4c-d4254f9b64aa.png)

This should reduce the e-mail noise from github caused by failing clang-format when it is actually running on nonsensical diffs.