### PR TITLE
Fixes #969: DataConnectionCountTest failure

### DIFF
--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -3268,6 +3268,7 @@ class DataConnectionCountTest(TestCase):
                 self.router.wait_ready()
                 self.router.wait_log_message(msg)
                 print("     good")
+                self.router.teardown()
 
         self.assertTrue(True)
 


### PR DESCRIPTION
The failure was actually that the config file was occasionally completely absent.
On my machine, this happened 2 out of 100 times.
Kgiusti suggested explicit call to teardown.
After that change, no failure in 300 runs.
Odds of that happening by chance are 0.98^300 ~= 0.0023 ~= 1 in 500.