### PR TITLE
Fixes #922: Suppress TSAN false race in 3rd party lib OpenSSL

### DIFF
--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -111,3 +111,8 @@ race:^qd_connection_manager_delete_listener$
 
 # DISPATCH-2156
 race:^pconnection_final_free$
+
+# ISSUE-922
+# Revisit?  So far restricted to openssl 3.0.5
+race:^ASN1_STRING_set$
+race:^ASN1_STRING_cmp$


### PR DESCRIPTION
see https://github.com/skupperproject/skupper-router/issues/922