### PR TITLE
Fixes #983: Removed integer offered capability values from test_50_ex…

### DIFF
--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -976,7 +976,6 @@ class OneRouterTest(TestCase):
         """
         client_caps = [symbol("single"),
                        ["A", "B", "C"],
-                       [9, 10, 11],
                        [],
                        None]
 


### PR DESCRIPTION
…tension_capabilities. The AMQP standard requires that there be symbol array or a single symbol