### PR TITLE
Issue #543: Suppress tsan race in libwebsockets `_lws_log` and `_lws_logv` on Ubuntu Focal in Travis

### DIFF
--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -79,6 +79,8 @@ race:^qdr_link_process_deliveries$
 race:^qdr_delivery_continue_CT$
 
 # ISSUE-543
+race:^_lws_log$
+race:^_lws_logv$
 race:^__lws_logv$
 
 # ISSUE-537 - Suppress the race in qd_entity_refresh_connector for now.


### PR DESCRIPTION
* See the #543 issue for details, links, logs, and speculations