### PR TITLE
Use Fedora 38 in GitHub Actions CI builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -313,7 +313,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         container: ['fedora']
-        containerTag: ['37']
+        containerTag: ['38']
         cc: [gcc]
         cxx: [g++]
         buildType: [RelWithDebInfo]
@@ -391,7 +391,7 @@ jobs:
           # unittest coverage
           - os: ubuntu-22.04
             container: 'fedora'
-            containerTag: 37
+            containerTag: 38
             cc: gcc
             cxx: g++
             buildType: Coverage
@@ -404,7 +404,7 @@ jobs:
           # clang
           - os: ubuntu-22.04
             container: 'fedora'
-            containerTag: 37
+            containerTag: 38
             cc: clang
             cxx: clang++
             buildType: RelWithDebInfo
@@ -414,7 +414,7 @@ jobs:
             shards: 2
           - os: ubuntu-22.04
             container: 'fedora'
-            containerTag: 37
+            containerTag: 38
             cc: clang
             cxx: clang++
             buildType: RelWithDebInfo
@@ -773,7 +773,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         container: ['fedora']
-        containerTag: ['37']
+        containerTag: ['38']
         buildType: [RelWithDebInfo]
         protonGitRef:
           - ${{ github.event.inputs.protonBranch || 'main' }}


### PR DESCRIPTION
Fedora 38 is currently a Beta, so it's I think a good time to start considering a switch in CI. https://fedorapeople.org/groups/schedule/f-38/f-38-key-tasks.html