### PR TITLE
Reorder `PyTypeObject` fields to match declaration order in `Python.h`

### DIFF
--- a/src/python_embedded.c
+++ b/src/python_embedded.c
@@ -559,12 +559,12 @@ static PyMethodDef LogAdapter_methods[] = {
 };
 
 static PyTypeObject LogAdapterType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base      = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name      = DISPATCH_MODULE ".LogAdapter",
-    .tp_doc       = "Dispatch Log Adapter",
     .tp_basicsize = sizeof(LogAdapter),
     .tp_dealloc   = (destructor)LogAdapter_dealloc,
     .tp_flags     = Py_TPFLAGS_DEFAULT,
+    .tp_doc       = "Dispatch Log Adapter",
     .tp_methods   = LogAdapter_methods,
     .tp_init      = (initproc)LogAdapter_init,
     .tp_new       = PyType_GenericNew,
@@ -807,14 +807,14 @@ static PyMethodDef IoAdapter_methods[] = {
 
 
 static PyTypeObject IoAdapterType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base      = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name      = DISPATCH_MODULE ".IoAdapter",
-    .tp_doc       = "Dispatch IO Adapter",
     .tp_basicsize = sizeof(IoAdapter),
-    .tp_traverse  = (traverseproc)IoAdapter_traverse,
-    .tp_clear     = (inquiry)IoAdapter_clear,
     .tp_dealloc   = (destructor)IoAdapter_dealloc,
     .tp_flags     = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_doc       = "Dispatch IO Adapter",
+    .tp_traverse  = (traverseproc)IoAdapter_traverse,
+    .tp_clear     = (inquiry)IoAdapter_clear,
     .tp_methods   = IoAdapter_methods,
     .tp_init      = (initproc)IoAdapter_init,
     .tp_new       = PyType_GenericNew,

--- a/src/router_pynode.c
+++ b/src/router_pynode.c
@@ -307,12 +307,12 @@ static PyMethodDef RouterAdapter_methods[] = {
 };
 
 static PyTypeObject RouterAdapterType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "dispatch.RouterAdapter",  /* tp_name*/
-    .tp_basicsize = sizeof(RouterAdapter),     /* tp_basicsize*/
-    .tp_flags = Py_TPFLAGS_DEFAULT,        /* tp_flags*/
-    .tp_doc = "Dispatch Router Adapter", /* tp_doc */
-    .tp_methods = RouterAdapter_methods,     /* tp_methods */
+    .ob_base      = PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name      = "dispatch.RouterAdapter",
+    .tp_basicsize = sizeof(RouterAdapter),
+    .tp_flags     = Py_TPFLAGS_DEFAULT,
+    .tp_doc       = "Dispatch Router Adapter",
+    .tp_methods   = RouterAdapter_methods,
 };
 
 


### PR DESCRIPTION
There is no particular reason in C why adhere to declaration order, but it's going to be neater if we do.

What prompted me to do this is my experiment https://github.com/skupperproject/skupper-router/pull/266 (because in C++ this order matters).