### PR TITLE
Issue #1011: Add the format `__attribute__` to still more functions

### DIFF
--- a/include/qpid/dispatch/error.h
+++ b/include/qpid/dispatch/error.h
@@ -70,7 +70,8 @@ ENUM_DECLARE(qd_error);
 
 qd_error_t qd_error_impl(qd_error_t code, const char *file, int line, const char *fmt, ...)
     __attribute__((format(printf, 4, 5)));
-qd_error_t qd_error_vimpl(qd_error_t code, const char *file, int line, const char *fmt, va_list ap);
+qd_error_t qd_error_vimpl(qd_error_t code, const char *file, int line, const char *fmt, va_list ap)
+    __attribute__((format(printf, 4, 0)));
 
 /**
  * Clear thread-local error code and message.

--- a/include/qpid/dispatch/log.h
+++ b/include/qpid/dispatch/log.h
@@ -53,7 +53,8 @@ void qd_log_impl(qd_log_source_t *source, qd_log_level_t level, const char *file
  */
 void qd_log_impl_v1(qd_log_source_t *source, qd_log_level_t level, const char *file, int line, const char *fmt, ...)
     __attribute__((format(printf, 5, 6)));
-void qd_vlog_impl(qd_log_source_t *source, qd_log_level_t level, bool check_level, const char *file, int line, const char *fmt, va_list ap);
+void qd_vlog_impl(qd_log_source_t *source, qd_log_level_t level, bool check_level, const char *file, int line, const char *fmt, va_list ap)
+    __attribute__((format(printf, 6, 0)));
 
 /** Log a message
  * Note: does not evaluate the format args unless the log message is enabled.

--- a/src/aprintf.h
+++ b/src/aprintf.h
@@ -24,7 +24,7 @@
 /**
    Variadic appending printf - see aprintf()
  */
-int vaprintf(char **begin, char *end, const char *format, va_list ap_in);
+int vaprintf(char **begin, char *end, const char *format, va_list ap_in) __attribute__((format(printf, 3, 0)));
 
 /**
    Appending printf.

--- a/src/message.c
+++ b/src/message.c
@@ -135,6 +135,7 @@ static void quote(char* bytes, int n, char **begin, char *end) {
 /**
  * Populates the buffer with formatted epoch_time
  */
+__attribute__((format(strftime, 2, 0)))
 static void format_time(pn_timestamp_t epoch_time, char *format, char *buffer, size_t len)
 {
     struct timeval local_timeval;

--- a/tests/clogger.c
+++ b/tests/clogger.c
@@ -97,7 +97,7 @@ const uint8_t msg_header[] = {
 };
 
 
-void debug(const char *format, ...)
+__attribute__((format(printf, 1, 2))) void debug(const char *format, ...)
 {
     va_list args;
 

--- a/tests/test-receiver.c
+++ b/tests/test-receiver.c
@@ -58,7 +58,7 @@ uint64_t count = 0;
 uint64_t limit = 0;   // if > 0 stop after limit messages arrive
 
 
-void debug(const char *format, ...)
+__attribute__((format(printf, 1, 2))) void debug(const char *format, ...)
 {
     va_list args;
 

--- a/tests/test-sender.c
+++ b/tests/test-sender.c
@@ -110,7 +110,7 @@ const char big_string[] =
     "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
 
 
-void debug(const char *format, ...)
+__attribute__((format(printf, 1, 2))) void debug(const char *format, ...)
 {
     va_list args;
 


### PR DESCRIPTION
I learned that functions which don't take actual format parameters can set the third argument to 0, and then the compiler simply syntax-checks the formatting string literal (and skips checking if the parameter types match.

This way, even functions that take `va_list`, or functions that fetch the parameters themselves, can be annotated.