### PR TITLE
ISSUE-1059: part 1: replace tcp echo server with asyncio implementation

### DIFF
--- a/tests/system_tests_tcp_adaptor.py
+++ b/tests/system_tests_tcp_adaptor.py
@@ -784,11 +784,6 @@ class CommonTcpTests:
                                         (test_name, es.prefix, es.error))
                         result = es.error
                         break
-                    if es.exit_status is not None:
-                        self.logger.log("TCP_TEST %s Server %s stopped with status: %s" %
-                                        (test_name, es.prefix, es.exit_status))
-                        result = es.exit_status
-                        break
                 if result is not None:
                     break
 
@@ -882,11 +877,6 @@ class CommonTcpTests:
                         self.logger.log("TCP_TEST %s Server %s stopped with error: %s" %
                                         (test_name, es.prefix, es.error))
                         result = es.error
-                        break
-                    if es.exit_status is not None:
-                        self.logger.log("TCP_TEST %s Server %s stopped with status: %s" %
-                                        (test_name, es.prefix, es.exit_status))
-                        result = es.exit_status
                         break
                 if result is not None:
                     break
@@ -998,11 +988,6 @@ class CommonTcpTests:
                         self.logger.log("TCP_TEST %s Server %s stopped with error: %s" %
                                         (test_name, es.prefix, es.error))
                         result = es.error
-                        break
-                    if es.exit_status is not None:
-                        self.logger.log("TCP_TEST %s Server %s stopped with status: %s" %
-                                        (test_name, es.prefix, es.exit_status))
-                        result = es.exit_status
                         break
                 if result is not None:
                     break


### PR DESCRIPTION
This patch replaces the current non-blocking TCP echo server with a much simpler asyncio based implementation as recommended by the python docs (see the see-also block):

https://docs.python.org/3/library/ssl.html#notes-on-non-blocking-sockets

This fixes the TCP test failures that involved SSL with the echo server. This does not fix the issues with the nginx TLS tests. That will need a followup fix.