### PR TITLE
Issue #1072: add `LSAN_DO_LEAK_CHECK` macro

### DIFF
--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -30,6 +30,7 @@
 #include "log_private.h"
 #include "message_private.h"
 #include "policy.h"
+#include "qd_asan_interface.h"
 #include "router_private.h"
 
 #include "qpid/dispatch/alloc.h"
@@ -372,6 +373,10 @@ static void qd_dispatch_set_router_area(qd_dispatch_t *qd, char *_area) {
 void qd_dispatch_free(qd_dispatch_t *qd)
 {
     if (!qd) return;
+
+    // Run a final lsan leakcheck right here (if lsan is enabled)
+    //  only leaks (i.e. memory made unreachable) before this point will be reported by lsan
+    LSAN_DO_LEAK_CHECK();
 
     /* Stop HTTP threads immediately */
     qd_http_server_free(qd_server_http(qd->server));


### PR DESCRIPTION
* https://github.com/skupperproject/skupper-router/issues/1072

This is just a proposal, but the general ideas are ready do be reviewed:

* https://github.com/skupperproject/skupper-router/issues/293

The motivation in the decision to close issue 293 is to call lsan explicitly and early. As a possible future extension, lsan could be runnable upon request from Python system_tests (via skmanage, for example)?

The disadvantage of this is that it will become impossible to start an lsan-enabled router multiple times in the same process (which is what (currently disabled) cpp_system tests do, (when run with lsan)). Whether such ability is (or might be in the future) valuable regarding improved testability is up to a discussion. From what I observed so far, it is not very promising avenue.

Other projects (like CPython) usually have some special leak-checking mode that is enabled with sanitizers. For example, python has an allocation list that collects all allocations so that they can be then orderly freed upon exit, if lsan is watching. This seems a bit too much like a silly workaround and waste of effort on first sight, but it gives them the ability to use this to fix leaks that happen during regular runtime (if you fix all leaks, then you will naturally fix also the important ones).