### PR TITLE
Add `-fno-omit-frame-pointer` option everywhere and always

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,14 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_ENABLE_EXPORTS TRUE)
 option(CMAKE_INTERPROCEDURAL_OPTIMIZATION "Perform link time optimization" ON)
 
+function(add_compile_link_options options)
+    add_compile_options(${options})
+    add_link_options(${options})
+endfunction()
+
+# preserve frame pointers for ease of debugging and profiling
+#  see https://fedoraproject.org/wiki/Changes/fno-omit-frame-pointer
+add_compile_link_options(-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer)
 
 # Set warning compile flags
 set(C_WARNING_GNU -Wall -Wextra -Werror -Wpedantic -pedantic-errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,9 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_ENABLE_EXPORTS TRUE)
 option(CMAKE_INTERPROCEDURAL_OPTIMIZATION "Perform link time optimization" ON)
 
-function(add_compile_link_options options)
-    add_compile_options(${options})
-    add_link_options(${options})
-endfunction()
-
 # preserve frame pointers for ease of debugging and profiling
 #  see https://fedoraproject.org/wiki/Changes/fno-omit-frame-pointer
-add_compile_link_options(-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer)
+add_compile_options(-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer)
 
 # Set warning compile flags
 set(C_WARNING_GNU -Wall -Wextra -Werror -Wpedantic -pedantic-errors


### PR DESCRIPTION
This follows the recent Fedora decision which seems imminently sound and well justified.

https://fedoraproject.org/wiki/Changes/fno-omit-frame-pointer

https://news.ycombinator.com/item?id=34426745

https://news.ycombinator.com/item?id=34632677