### PR TITLE
Create GitHub Actions Workflows for CodeQL, Clang Analyzer and GCC -fanalyzer

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
+
+# https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#using-a-custom-configuration-file
+
+name: "Skupper-router CodeQL config"
+
+# https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+paths-ignore:
+  - tests/

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -1,0 +1,121 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
+
+name: "clang-analyzer"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '32 16 * * 4'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+
+    env:
+      CC: clang
+      CXX: clang++
+
+    steps:
+    - name: Checkout router repository
+      uses: actions/checkout@v3
+
+    - name: Checkout Proton repository
+      uses: actions/checkout@v3
+      with:
+        repository: apache/qpid-proton
+        ref: main
+        path: 'qpid-proton'
+
+    - name: Install latest llvm
+      run: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+    - name: Install cppcheck
+      run: sudo apt install -y cppcheck
+
+    - name: Install dependencies
+      run: |
+        sudo apt update; sudo apt install -y libdw-dev swig libpython3-dev libsasl2-dev libjsoncpp-dev libwebsockets-dev libnghttp2-dev ccache ninja-build pixz libbenchmark-dev nginx
+
+    - name: Install Proton
+      run: |
+        cmake -S qpid-proton -B qpid-proton/install -DBUILD_BINDINGS=c -DBUILD_TLS=ON -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
+        cmake --build qpid-proton/install
+        sudo cmake --install qpid-proton/install
+
+    - name: Delete Proton
+      run: rm -rf qpid-proton
+
+    # https://clang-analyzer.llvm.org/command-line.html
+    - name: Create compilation database
+      run: |
+        sudo pip3 install codechecker
+        # disable IPO to make compilation faster
+        cmake -S . -B build -DBUILD_TESTING=OFF -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DQD_ENABLE_ASSERTIONS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        # perform build so that generated sources get generated
+        cmake --build build
+        CodeChecker analyze build/compile_commands.json -o ./reports
+        # return code 2 seems to mean issues were found, return code 3 means some checkers failed to run
+        # print readable textual output of results
+        CodeChecker parse --print-steps ./reports || true
+        CodeChecker parse --print-steps --export html --output report_html ./reports || true
+
+    - name: Upload rendered HTML
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: report_html/
+
+  publish:
+    name: "Publish"
+
+    needs: analyze
+    if: github.ref_name == 'main'
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    # Allow one concurrent deployment
+    concurrency:
+      group: "github-pages-codechecker"
+      cancel-in-progress: true
+
+    environment:
+      name: github-pages-codechecker
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      # https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,94 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '32 16 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: [ 'cpp', 'python' ]
+
+    steps:
+    - name: Checkout router repository
+      uses: actions/checkout@v3
+
+    - name: Checkout Proton repository
+      uses: actions/checkout@v3
+      with:
+        repository: apache/qpid-proton
+        ref: main
+        path: 'qpid-proton'
+
+    - name: Install Proton
+      run: |
+        cmake -S qpid-proton -B qpid-proton/install -DBUILD_BINDINGS=c -DBUILD_TLS=ON -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
+        cmake --build qpid-proton/install
+        sudo cmake --install qpid-proton/install
+
+    - name: Delete Proton
+      run: rm -rf qpid-proton
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+
+        config-file: ./.github/codeql/codeql-config.yml
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # queries: security-extended,security-and-quality
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y libdw-dev swig libpython3-dev libsasl2-dev libjsoncpp-dev libwebsockets-dev libnghttp2-dev ccache ninja-build pixz libbenchmark-dev nginx
+
+    - name: Build
+      run: |
+        cmake -S . -B build -GNinja -DENABLE_WARNING_ERROR=OFF -DQD_ENABLE_ASSERTIONS=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DBUILD_TESTING=OFF
+        cmake --build build
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/gcc-fanalyzer.yml
+++ b/.github/workflows/gcc-fanalyzer.yml
@@ -1,0 +1,114 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
+
+name: "gcc-fanalyzer"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '32 16 * * 4'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      # https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security
+      security-events: write
+
+    container:
+      image: 'quay.io/fedora/fedora:rawhide'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+      options: --privileged --ulimit core=-1 --security-opt apparmor:unconfined --security-opt seccomp=unconfined --sysctl net.ipv6.conf.all.disable_ipv6=0
+
+    steps:
+
+    - name: Install dependencies
+      run: |
+        dnf install -y gcc gcc-c++ ninja-build cmake \
+        cyrus-sasl-devel openssl-devel libuuid-devel \
+        python3-devel python3-pip \
+        libnghttp2-devel libwebsockets-devel \
+        wget tar patch findutils git
+
+    - name: Checkout router repository
+      uses: actions/checkout@v3
+
+    - name: Checkout Proton repository
+      uses: actions/checkout@v3
+      with:
+        repository: apache/qpid-proton
+        ref: main
+        path: 'qpid-proton'
+
+    - name: Take ownership of the checkout directory (Git CVE-2022-24765)
+      run: chown --recursive --reference=/ .
+
+    - name: Install Proton
+      run: |
+        cmake -S qpid-proton -B qpid-proton/build -GNinja -DBUILD_BINDINGS=c -DBUILD_TLS=ON -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
+        cmake --build qpid-proton/build
+        cmake --install qpid-proton/build
+
+    - name: Delete Proton
+      run: rm -rf qpid-proton
+
+    # https://gcc.gnu.org/wiki/StaticAnalyzer
+    - name: Build with -fanalyzer
+      run: |
+        # Disable IPO to avoid out-of-memory crashes when compiling with -fanalyzer
+        CFLAGS="-fanalyzer -fdiagnostics-format=sarif-file" CXXFLAGS="-fanalyzer -fdiagnostics-format=sarif-file" cmake -S . -B build -GNinja -DENABLE_WARNING_ERROR=OFF -DQD_ENABLE_ASSERTIONS=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DBUILD_TESTING=OFF
+        cmake --build build
+      working-directory: ${{github.workspace}}
+
+    # https://github.com/microsoft/sarif-sdk/blob/main/docs/multitool-usage.md
+    - name: Combine sarifs
+      run: |
+        dnf install -y npm
+        npm install -g @microsoft/sarif-multitool
+        npx -y @microsoft/sarif-multitool merge $(find build/ -name '*.sarif') --recurse --output-file merged.sarif
+        python3 scripts/gha_sarif_masher.py --basedir "${PWD}" --output mashed.sarif merged.sarif
+        npx -y @microsoft/sarif-multitool rewrite mashed.sarif --normalize-for-ghas --output current.sarif --sarif-output-version Current
+      env:
+        DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
+      working-directory: ${{github.workspace}}
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: current.sarif
+        path: current.sarif
+
+    # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github
+    - name: upload sarif file to github
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: current.sarif
+        # Optional category for the results
+        # Used to differentiate multiple results for one commit
+        category: /gcc-fanalyzer

--- a/.github/workflows/gcc-fanalyzer.yml
+++ b/.github/workflows/gcc-fanalyzer.yml
@@ -91,7 +91,7 @@ jobs:
       run: |
         dnf install -y npm
         npm install -g @microsoft/sarif-multitool
-        npx -y @microsoft/sarif-multitool merge $(find build/ -name '*.sarif') --recurse --output-file merged.sarif
+        npx -y @microsoft/sarif-multitool merge $(find build/ -name '*.sarif') --output-file merged.sarif
         python3 scripts/gha_sarif_masher.py --basedir "${PWD}" --output mashed.sarif merged.sarif
         npx -y @microsoft/sarif-multitool rewrite mashed.sarif --normalize-for-ghas --output current.sarif --sarif-output-version Current
       env:

--- a/docs/notes/sarif.md
+++ b/docs/notes/sarif.md
@@ -1,0 +1,31 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one -->
+<!-- or more contributor license agreements.  See the NOTICE file -->
+<!-- distributed with this work for additional information -->
+<!-- regarding copyright ownership.  The ASF licenses this file -->
+<!-- to you under the Apache License, Version 2.0 (the -->
+<!-- "License"); you may not use this file except in compliance -->
+<!-- with the License.  You may obtain a copy of the License at -->
+
+<!--   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- Unless required by applicable law or agreed to in writing, -->
+<!-- software distributed under the License is distributed on an -->
+<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!-- KIND, either express or implied.  See the License for the -->
+<!-- specific language governing permissions and limitations -->
+<!-- under the License. -->
+
+# SARIF (Static Analysis Results Interchange Format)
+
+[Introduction from Microsoft](https://github.com/microsoft/sarif-tutorials).
+
+SARIF is a format based on JSON, used to capture warning messages from software tools that work with sourcecode.
+Most importantly it can hold compiler warnings and findings from security scanners.
+GitHub can then import these and maintain a browsable database of outstanding ones.
+
+## Helpful tooling
+
+- [SARIF validator](https://sarifweb.azurewebsites.net/Validation)
+- [SARIF multitool for merging and manipulating .sarif files](https://github.com/microsoft/sarif-sdk/blob/main/docs/multitool-usage.md)
+  - [GitHub action to invoke the tool](https://github.com/marketplace/actions/sarif-multitool)
+- [GitHub documentation about importing SARIF results](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github)

--- a/scripts/gha_sarif_masher.py
+++ b/scripts/gha_sarif_masher.py
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
+
+import argparse
+import json
+import posixpath
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog='gha_sarif_masher',
+        description='Processes SARIF files from GCC so that GitHub Actions ingest them.',
+        epilog='This complements @microsoft/sarif-multitool with additional transformations.')
+    parser.add_argument('filename', type=argparse.FileType('rt'))
+    parser.add_argument('--output', required=True, type=argparse.FileType('wt'))
+    parser.add_argument('--basedir', required=True)
+
+    args = parser.parse_args()
+    filename = args.filename
+    output = args.output
+    basedir = args.basedir
+
+    sarif = json.load(filename)
+
+    relativize_urls(sarif, basedir=basedir)
+    fill_in_missing_pysicalLocations(sarif)
+
+    json.dump(sarif, fp=output)
+
+
+def iterate_subtrees(o):
+    """Walks a json object and yields each subtree of it in turn."""
+    yield o
+    if isinstance(o, dict):
+        for _, v in o.items():
+            yield from iterate_subtrees(v)
+    elif isinstance(o, list):
+        for i in o:
+            yield from iterate_subtrees(i)
+
+
+def relativize_urls(sarif, basedir):
+    """GitHub SARIF importer expects file urls to be relative to the root of the repository."""
+    for item in iterate_subtrees(sarif):
+        if not isinstance(item, dict):
+            continue
+        if 'uri' in item:
+            item['uri'] = posixpath.relpath(item['uri'], start=basedir)
+
+
+
+def fill_in_missing_pysicalLocations(sarif):
+    """GitHub SARIF importer requires physicalLocation to be present, otherwise
+    the following error is raised.
+
+    `Code Scanning could not process the submitted SARIF file: buildCodeFlows: expected physical location`
+    """
+    for item in iterate_subtrees(sarif):
+        if not isinstance(item, dict):
+            continue
+        if 'location' in item and 'physicalLocation' not in item['location']:
+            item['location']['physicalLocation'] = {
+                'artifactLocation': {
+                    'uri': 'gcc/associated/no/file'
+                }
+            }
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
* Depends on https://github.com/skupperproject/skupper-router/pull/1111

TODO: put the information below into a file under docs/

Code scanning is a GitHub feature https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security

Findings from CodeQL and GCC -fanalyzer get reported to https://github.com/skupperproject/skupper-router/security/code-scanning

Findings from clang (through CodeChecker) get reported in a github-pages-codechecker deployment webpage, which is not yet available, because it only deploys from main branch, but it will look like https://github.com/jiridanek/skupper-router/deployments/activity_log?environment=github-pages-codechecker

Checks available in clang are documented at https://clang.llvm.org/docs/analyzer/checkers.html The Cross Translation Unit analysis mode is not turned on in this PR just yet, https://clang.llvm.org/docs/analyzer/user-docs/CrossTranslationUnit.html#automated-ctu-analysis-with-codechecker

CodeChecker is recommended tool to run clang analyzer, docs are at https://github.com/Ericsson/codechecker/blob/master/docs/usage.md

