### PR TITLE
Migrate from rpkg to packit as rpkg is not available on CentOS Stream 9

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -834,7 +834,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-20.04' ]
         container: [ 'centos' ]
-        containerTag: [ 'stream8' ]
+        containerTag: [ 'stream9' ]
 
     container:
       image: 'quay.io/${{ matrix.container }}/${{ matrix.container }}:${{ matrix.containerTag }}'
@@ -845,31 +845,40 @@ jobs:
       DNF: ${{github.workspace}}/build
 
     steps:
-      - name: Install build dependencies (1/2)
+
+      - name: Enable additional package repositories for CentOS 8
+        if: ${{ matrix.container == 'centos' && matrix.containerTag == 'stream8' }}
         run: |
-          dnf install -y 'dnf-command(config-manager)'
+          dnf -y install epel-release 'dnf-command(config-manager)'
           dnf config-manager --set-enabled powertools
-          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y epel-release 'dnf-command(copr)' 'dnf-command(builddep)'
-          dnf copr enable -y clime/rpkg-util
-          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y git rpkg libunwind-devel
+
+      - name: Enable additional package repositories for CentOS 9
+        if: ${{ matrix.container == 'centos' && matrix.containerTag == 'stream9' }}
+        run: |
+          dnf -y install epel-release 'dnf-command(config-manager)'
+          dnf config-manager --set-enabled crb
+
+      - name: Install packit
+        run: |
+          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y epel-release
+          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y git packit
 
       - uses: actions/checkout@v3
 
       - name: Take ownership of the checkout directory (Git CVE-2022-24765)
         run: chown --recursive --reference=/ .
 
-      - name: Deploy the spec.rpkg file to /
-        run: ln -s packaging/skupper-router.spec.rpkg ./
-
-      - name: Install build dependencies (2/2)
+      - name: Install srpm build dependencies
         run: |
-          rpkg spec --outdir /tmp/rpkg
-          dnf builddep --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y /tmp/rpkg/skupper-router.spec
+          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y 'dnf-command(builddep)'
+          dnf builddep --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y packaging/skupper-router.spec
 
-      - name: Build packages
+      - name: Build skupper-router src.rpm and the rpm packages
         run: |
           mkdir /tmp/skupper-rpms
-          rpkg local --nocheck --outdir /tmp/skupper-rpms
+
+          packit srpm
+          rpmbuild --rebuild skupper-router*.src.rpm --nocheck --define '_rpmdir /tmp/skupper-rpms' --define 'debug_package %{nil}'
 
       - name: Install built packages
         run: |

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# https://packit.dev/docs/configuration/#top-level-keys
+upstream_project_url: https://github.com/skupperproject/skupper-router
+issue_repository: https://github.com/skupperproject/skupper-router
+
+specfile_path: packaging/skupper-router.spec
+
+# add or remove files that should be synced
+files_to_sync:
+  - .packit.yaml
+
+# name in upstream package repository/registry (e.g. in PyPI)
+upstream_package_name: skupper-router
+# downstream (Fedora) RPM package name
+downstream_package_name: skupper-router

--- a/packaging/skupper-router.spec
+++ b/packaging/skupper-router.spec
@@ -19,15 +19,14 @@
 
 # Tutorial for .spec files is available at https://rpm-packaging-guide.github.io
 
-# This .spec file uses `rpkg` (https://pagure.io/rpkg-util) to provide
+# This .spec file uses `packit` (https://packit.dev/docs/cli/srpm/) to provide
 # pleasant user experience to developers.
-# rpkg-util v3 is required, v2 will fail to recognize some macros in this file.
 #
-#  Command                  Description
-# `rpkg srpm`              Creates a *.src.rpm file in /tmp/rpkg (exact path is printed)
-# `rpkg local --nocheck`   Builds a *.rpm for your system in /tmp/rpkg (exact path is printed)
+#  Command                           Description
+# `packit srpm`                      Creates a *.src.rpm file in the local directory (exact path is printed)
+# `packit build locally`             Builds a *.rpm for your system in the local directory (exact path is printed)
 #
-# See `man rpkg` for more commands. See `man rpkg-macros` for explanation of the triple-{ macros.
+# See `man packit` for more commands. See https://packit.dev/docs/actions/#fix-spec-file for explanation of "actions".
 
 # not undefine, that would break COPR, https://pagure.io/rpkg-util/issue/44
 %define _disable_source_fetch 0
@@ -45,12 +44,11 @@
 %global libunwind_minimum_version 1.3.1
 
 Name:          skupper-router
-Version:       {{{ git_dir_version }}}
-Release:       2.0.0%{?dist}
+Version:       2.x.y
+Release:       1%{?dist}
 Summary:       The skrouterd router daemon for Skupper.io
 License:       ASL 2.0
 URL:           https://skupper.io
-VCS:           {{{ git_dir_vcs }}}
 
 Requires: python3
 Requires: skupper-router-common == %{version}
@@ -81,7 +79,7 @@ BuildRequires: openssl-devel
 BuildRequires: cyrus-sasl-devel
 
 # skupper-router sources
-Source0: {{{ git_dir_pack }}}
+Source0: packit-placeholder-value.tar.gz
 # vendored qpid-proton
 Source1: https://www.apache.org/dist/qpid/proton/%{proton_vendored_version}/qpid-proton-%{proton_vendored_version}.tar.gz
 
@@ -89,7 +87,7 @@ Source1: https://www.apache.org/dist/qpid/proton/%{proton_vendored_version}/qpid
 A lightweight message router, written in C and built on Qpid Proton, that provides flexible and scalable interconnect backend for Skupper.io Level 7 Virtual Application Network.
 
 %prep
-{{{ git_dir_setup_macro }}}
+%setup -T -b 0 -q -n skupper-router
 %setup -q -D -b 1 -n qpid-proton-%{proton_vendored_version}
 
 %build
@@ -103,12 +101,12 @@ cd %{_builddir}/qpid-proton-%{proton_vendored_version}
     -DBUILD_BINDINGS=OFF \
     -DBUILD_TLS=ON -DSSL_IMPL=openssl \
     -DBUILD_STATIC_LIBS=ON \
-    -DCMAKE_POLICY_DEFAULT_CMP0069=NEW -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
     -DCMAKE_INSTALL_PREFIX=%{proton_install_prefix}
 %__cmake --build "%{__cmake_builddir}" %{?_smp_mflags} --verbose
 %__cmake --install "%{__cmake_builddir}"
 
-cd %{_builddir}/skupper-router
+cd %{_builddir}/skupper-router-%{version}
 %cmake \
     -DVERSION="%{version}" \
     -DPython_EXECUTABLE=%{python3} \
@@ -118,11 +116,11 @@ cd %{_builddir}/skupper-router
 %cmake_build --target all --target man
 
 %install
-cd %{_builddir}/skupper-router
+cd %{_builddir}/skupper-router-%{version}
 %cmake_install
 
 %check
-cd %{_builddir}/skupper-router
+cd %{_builddir}/skupper-router-%{version}
 %ctest
 
 %files
@@ -197,4 +195,4 @@ BuildArch: noarch
 %license /usr/share/doc/skupper-router/LICENSE
 
 %changelog
-{{{ git_dir_changelog }}}
+%autochangelog

--- a/packaging/skupper-router.spec
+++ b/packaging/skupper-router.spec
@@ -73,6 +73,7 @@ BuildRequires: asciidoc
 BuildRequires: python3-qpid-proton >= %{proton_minimum_version}
 # check ctest
 BuildRequires: cyrus-sasl-plain
+BuildRequires: openssl
 
 # proton-c requirements
 BuildRequires: openssl-devel

--- a/packaging/skupper-router.spec.rpkg
+++ b/packaging/skupper-router.spec.rpkg
@@ -131,10 +131,7 @@ cd %{_builddir}/skupper-router
 %config /etc/skupper-router/skrouterd.conf
 %config /etc/sasl2/skrouterd.conf
 
-%{python3_sitelib}/skupper_router/
-%{python3_sitelib}/skupper_router_site.py
-%{python3_sitelib}/__pycache__/skupper_router_site.*.pyc
-%{python3_sitelib}/skupper_router-*.egg-info
+%{python3_sitelib}/
 
 /usr/share/man/man5/skrouterd.conf.5.gz
 /usr/share/man/man8/skrouterd.8.gz


### PR DESCRIPTION
I cannot simply change CentOS image from 8 to 9, because rpkg does not have packages for CentOS 9. That means upgrading to packit is required. See

* https://github.com/skupperproject/skupper-router/issues/1013

and the links there for why packit is so awesome. (Mostly because it is the new hot thing that is getting tender love and care, as opposed to the older approaches that are left to rot.)

This PR is a lightweight version of

* https://github.com/skupperproject/skupper-router/pull/1014

because it only uses packit to do local build and does not use the CI features.

edit: Looks like packit will run the CI tests on its own by default... well, that is nice bonus, right?