### PR TITLE
Issue #1141: Run Containerfile tests serially in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -945,9 +945,11 @@ jobs:
       - name: Compile and run .rs tests
         run: |
           cargo check
-          cargo test -- --nocapture
+          cargo test -- --test-threads=1 --nocapture
         env:
           QDROUTERD_IMAGE: local/skupper-router:local
+          CARGO_INCREMENTAL: 0
+          RUST_LOG: info
           RUST_BACKTRACE: 1
 
   rpm:

--- a/tests/testcontainers/README.adoc
+++ b/tests/testcontainers/README.adoc
@@ -32,6 +32,16 @@ systemctl --user enable --now podman.socket
 export DOCKER_HOST=unix:///run/user/${UID}/podman/podman.sock
 ----
 
+## running tests
+
+[source,shell script]
+----
+# Set QDROUTERD_IMAGE variable to the router image name to be tested
+export QDROUTERD_IMAGE=localhost/local/skupper-router
+export RUST_LOG=info
+cargo test -- --test-threads=1 --nocapture
+----
+
 ## atomic test containers
 
 Tests are implemented as Rust tests that run various container


### PR DESCRIPTION
This does not fix the issue, but it ensures that logs are more sensible since logs from test cases no longer overlap.

The running of tests is now explained in tests/testcontainers/README.adoc