### PR TITLE
GHA CI: add missing cffi package for proton dependency (#1165)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,7 +135,7 @@ jobs:
           architecture: x64
 
       - name: Install Python build dependencies
-        run: python -m pip install setuptools wheel tox
+        run: python -m pip install setuptools wheel tox cffi
 
       - name: Install Linux build dependencies
         run: |
@@ -521,7 +521,7 @@ jobs:
         run: dnf install -y util-linux-core python3-devel python3-pip
 
       - name: Install Python build dependencies
-        run: python3 -m pip install setuptools wheel tox
+        run: python3 -m pip install setuptools wheel tox cffi
 
       # https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files


### PR DESCRIPTION
(cherry picked from commit b9ffb33ece1c4b324bbc9a986ba0c4ac024bd064)