### PR TITLE
2.4.x ci fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -822,7 +822,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-20.04' ]
         container: [ 'centos' ]
-        containerTag: [ 'stream8' ]
+        containerTag: [ 'stream9' ]
 
     container:
       image: 'quay.io/${{ matrix.container }}/${{ matrix.container }}:${{ matrix.containerTag }}'
@@ -833,31 +833,40 @@ jobs:
       DNF: ${{github.workspace}}/build
 
     steps:
-      - name: Install build dependencies (1/2)
+
+      - name: Enable additional package repositories for CentOS 8
+        if: ${{ matrix.container == 'centos' && matrix.containerTag == 'stream8' }}
         run: |
-          dnf install -y 'dnf-command(config-manager)'
+          dnf -y install epel-release 'dnf-command(config-manager)'
           dnf config-manager --set-enabled powertools
-          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y epel-release 'dnf-command(copr)' 'dnf-command(builddep)'
-          dnf copr enable -y clime/rpkg-util
-          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y git rpkg libunwind-devel
+
+      - name: Enable additional package repositories for CentOS 9
+        if: ${{ matrix.container == 'centos' && matrix.containerTag == 'stream9' }}
+        run: |
+          dnf -y install epel-release 'dnf-command(config-manager)'
+          dnf config-manager --set-enabled crb
+
+      - name: Install packit
+        run: |
+          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y epel-release
+          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y git packit
 
       - uses: actions/checkout@v3
 
       - name: Take ownership of the checkout directory (Git CVE-2022-24765)
         run: chown --recursive --reference=/ .
 
-      - name: Deploy the spec.rpkg file to /
-        run: ln -s packaging/skupper-router.spec.rpkg ./
-
-      - name: Install build dependencies (2/2)
+      - name: Install srpm build dependencies
         run: |
-          rpkg spec --outdir /tmp/rpkg
-          dnf builddep --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y /tmp/rpkg/skupper-router.spec
+          dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y 'dnf-command(builddep)'
+          dnf builddep --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y packaging/skupper-router.spec
 
-      - name: Build packages
+      - name: Build skupper-router src.rpm and the rpm packages
         run: |
           mkdir /tmp/skupper-rpms
-          rpkg local --nocheck --outdir /tmp/skupper-rpms
+
+          packit srpm
+          rpmbuild --rebuild skupper-router*.src.rpm --nocheck --define '_rpmdir /tmp/skupper-rpms' --define 'debug_package %{nil}'
 
       - name: Install built packages
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
         runtimeCheck: [asan]
         protonGitRef:
           - ${{ github.event.inputs.protonBranch || 'main' }}
-          - 0.38.0
+          - 0.39.0
     env:
       BuildType: ${{matrix.buildType}}
       ProtonBuildDir: ${{github.workspace}}/qpid-proton/build
@@ -207,7 +207,7 @@ jobs:
         runtimeCheck: [asan]
         protonGitRef:
           - ${{ github.event.inputs.protonBranch || 'main' }}
-          - 0.38.0
+          - 0.39.0
         shard: [1, 2]
         shards: [2]
     env:
@@ -316,7 +316,7 @@ jobs:
         runtimeCheck: [asan, tsan]
         protonGitRef:
           - ${{ github.event.inputs.protonBranch || 'main' }}
-          - 0.38.0
+          - 0.39.0
         shard: [ 1, 2 ]
         shards: [ 2 ]
         include:
@@ -364,7 +364,7 @@ jobs:
             cc: gcc
             cxx: g++
             runtimeCheck: OFF
-            protonGitRef: 0.38.0
+            protonGitRef: 0.39.0
             shard: 1
             shards: 2
           - os: ubuntu-20.04
@@ -373,7 +373,7 @@ jobs:
             cc: gcc
             cxx: g++
             runtimeCheck: OFF
-            protonGitRef: 0.38.0
+            protonGitRef: 0.39.0
             shard: 2
             shards: 2
           # coverage
@@ -384,7 +384,7 @@ jobs:
             cxx: g++
             buildType: Coverage
             runtimeCheck: OFF
-            protonGitRef: 0.38.0
+            protonGitRef: 0.39.0
             routerCTestExtraArgs: "-R 'unittests|unit_tests|threaded_timer_test|adaptor_buffer_test|router_engine_test|management_test|router_policy_test|test_command'"
             shard: 1
             shards: 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -789,6 +789,20 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      # https://podman.io/docs/installation#ubuntu
+      - name: Upgrade Podman
+        run: |
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key \
+          | gpg --dearmor \
+          | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
+            https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
+          | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
+          sudo apt-get update -qq
+          sudo apt-get -qq -y install podman
+
       - name: Build Containerfile
         run: |
           podman build -t local/skupper-router:local -f ./Containerfile .

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# https://packit.dev/docs/configuration/#top-level-keys
+upstream_project_url: https://github.com/skupperproject/skupper-router
+issue_repository: https://github.com/skupperproject/skupper-router
+
+specfile_path: packaging/skupper-router.spec
+
+# add or remove files that should be synced
+files_to_sync:
+  - .packit.yaml
+
+# name in upstream package repository/registry (e.g. in PyPI)
+upstream_package_name: skupper-router
+# downstream (Fedora) RPM package name
+downstream_package_name: skupper-router

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ find_library(rt_lib rt)
 
 find_package(Python 3.6.8 REQUIRED COMPONENTS Interpreter Development)
 find_package(Threads REQUIRED)
-find_package(Proton 0.38.0 REQUIRED COMPONENTS Core Proactor Tls)
+find_package(Proton 0.39.0 REQUIRED COMPONENTS Core Proactor Tls)
 message(STATUS "Found Proton: ${Proton_LIBRARIES} (found version \"${Proton_VERSION}\")" )
 
 # http2 support

--- a/packaging/skupper-router.spec.rpkg
+++ b/packaging/skupper-router.spec.rpkg
@@ -36,10 +36,10 @@
 
 # This package builds and statically links against its own proton-c library
 # so we can use newest Proton features even before it is packaged for our distro
-%global proton_vendored_version 0.38.0
+%global proton_vendored_version 0.39.0
 %define proton_install_prefix %{_builddir}/qpid-proton-%{proton_vendored_version}/install
 
-%global proton_minimum_version 0.34.0
+%global proton_minimum_version 0.37.0
 %global libwebsockets_minimum_version 3.0.1
 %global libnghttp2_minimum_version 1.33.0
 %global libunwind_minimum_version 1.3.1

--- a/tests/system_tests_tcp_adaptor.py
+++ b/tests/system_tests_tcp_adaptor.py
@@ -1118,6 +1118,15 @@ class CommonTcpTests:
     @unittest.skipIf(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
     def test_20_tcp_connect_disconnect(self):
         name = "test_20_tcp_connect_disconnect"
+        # This test starts an echo pair on Router INTA. The echo client opens a connection
+        # to INTA and immediately closes the connection without sending any data (sizes=[0])
+        # The router *might* open a connection to the echo server
+        # in some cases, and in other cases, the router might sense that the client connection has
+        # already been closed by the echo client without sending any data and hence the router will
+        # not bother to open a connection on the server side. This really depends on how fast the router
+        # gets the disconnect event from the proton raw connection API.
+        # The connectionsOpened and connectionsClosed counters might not match depending on if the
+        # server side connection was created or not.
         self.logger.log("TCP_TEST Start %s" % name)
         pairs = [self.EchoPair(self.INTA, self.INTA, sizes=[0])]
         result = self.do_tcp_echo_n_routers(name, pairs, test_ssl=self.test_ssl)
@@ -1283,7 +1292,9 @@ class CommonTcpTests:
             assert "connectionsOpened" in output
             assert output["connectionsOpened"] > 0
             # egress_dispatcher connection opens and should never close
-            assert output["connectionsOpened"] == output["connectionsClosed"] + 1
+            if ncat_available():
+                # See the comments in test_20_tcp_connect_disconnect()
+                self.assertIn(output["connectionsOpened"], (output["connectionsClosed"] + 1, output["connectionsClosed"] + 2))
             assert output["bytesIn"] == output["bytesOut"]
         self.logger.log(tname + " SUCCESS")
 


### PR DESCRIPTION
I'm trying to get CI to pass on the 2.4.x branch by backporting CI fixes that are on main but missing from 2.4.x.

With this patch the only test that fails is the Container Image build, but I'm a little unclear as to which commit on main needs to be backported to fix this:

https://github.com/kgiusti/skupper-router/actions/runs/5580430927/jobs/10213011451#step:7:21

Any ideas?  Thanks.