### PR TITLE
NO-ISSUE: Hardcode test timeout for Python systemtests as 1200s

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,6 +186,7 @@ foreach(py_test_module
   string(CONFIGURE "${PYTHON_TEST_COMMAND}" CONFIGURED_PYTHON_TEST_COMMAND)
 
   add_test(${py_test_module} ${TEST_WRAP} ${CONFIGURED_PYTHON_TEST_COMMAND})
+  set_tests_properties(${py_test_module} PROPERTIES TIMEOUT 1200)
   list(APPEND SYSTEM_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${py_test_module}.py)
 endforeach()
 


### PR DESCRIPTION
I thought we'd need to set `ctest --timeout`, then. But, looking into logs, we already set `--timeout`,

```
ctest --timeout 1200 -V --output-junit=Testing/Test.xml --output-on-failure --no-compress-output -I 2,,2 -j${threads}
```

So I tried https://github.com/skupperproject/skupper-router/pull/1216 which seems to work. But still, `--timeout` being ignored is weird.  On my machine, I can use --timeout only to _decrease_ the timeout, such as `--timeout 400`, but not to increase.

Maybe releated to https://gitlab.kitware.com/cmake/cmake/-/issues/23979