### PR TITLE
NO-ISSUE: remove outdated flag from proton build in rpm spec

### DIFF
--- a/packaging/skupper-router.spec
+++ b/packaging/skupper-router.spec
@@ -95,9 +95,7 @@ A lightweight message router, written in C and built on Qpid Proton, that provid
 %build
 %set_build_flags
 cd %{_builddir}/qpid-proton-%{proton_vendored_version}
-# PROTON-2473: -Wno-error=deprecated-declarations for DH_new, DH_...
 %__cmake . -B "%{__cmake_builddir}" \
-    -DCMAKE_C_FLAGS="$CFLAGS -Wno-error=deprecated-declarations" \
     -DBUILD_TOOLS=OFF \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_TESTING=OFF \


### PR DESCRIPTION
`-Wno-error=deprecated-declarations` is no longer necessary

See https://issues.apache.org/jira/projects/PROTON/issues/PROTON-2473, which explains that the warning is now suppressed in Proton itself. So while the core issue is not resolved, the warning suppression flag is not necessary to be passed from the outside.