### PR TITLE
Fixes #1270: install all python prerequisites for RPM build

### DIFF
--- a/.github/scripts/compile.sh
+++ b/.github/scripts/compile.sh
@@ -157,7 +157,7 @@ cmake -S "${SKUPPER_DIR}" -B "${SKUPPER_BUILD_DIR}" \
 cmake --build "${SKUPPER_BUILD_DIR}" --verbose
 
 # Install Proton Python
-python3 -m pip install --ignore-installed --prefix="$PROTON_INSTALL_DIR/usr" "$(find "$PROTON_BUILD_DIR/python/" -name 'python-qpid-proton-*.tar.gz')"
+python3 -m pip install --disable-pip-version-check --ignore-installed --prefix="$PROTON_INSTALL_DIR/usr" "$(find "$PROTON_BUILD_DIR/python/" -name 'python-qpid-proton-*.tar.gz')"
 
 tar -z -C "${PROTON_INSTALL_DIR}" -cf /qpid-proton-image.tar.gz usr
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -997,6 +997,10 @@ jobs:
           packit srpm
           rpmbuild --rebuild skupper-router*.src.rpm --nocheck --define '_rpmdir /tmp/skupper-rpms' --define 'debug_package %{nil}'
 
+      - name: List package content
+        run: |
+          rpm -qlp /tmp/skupper-rpms/*/*.rpm
+
       - name: Install built packages
         run: |
           dnf install -y /tmp/skupper-rpms/*/*.rpm

--- a/packaging/skupper-router.spec
+++ b/packaging/skupper-router.spec
@@ -38,6 +38,7 @@
 %global proton_vendored_version 0.39.0
 %define proton_install_prefix %{_builddir}/qpid-proton-%{proton_vendored_version}/install
 
+%global python_minimum_version 3.9.0
 %global proton_minimum_version 0.37.0
 %global libwebsockets_minimum_version 3.0.1
 %global libnghttp2_minimum_version 1.33.0
@@ -63,9 +64,11 @@ BuildRequires: gcc-c++
 BuildRequires: cmake
 
 # skupper-router requirements
-BuildRequires: python3-devel
+BuildRequires: python3-devel >= %{python_minimum_version}
 BuildRequires: python3-setuptools
+BuildRequires: python3-wheel
 BuildRequires: python3-pip
+BuildRequires: python3-rpm-macros
 BuildRequires: libwebsockets-devel >= %{libwebsockets_minimum_version}
 BuildRequires: libnghttp2-devel >= %{libnghttp2_minimum_version}
 BuildRequires: libunwind-devel >= %{libunwind_minimum_version}
@@ -75,6 +78,10 @@ BuildRequires: python3-qpid-proton >= %{proton_minimum_version}
 # check ctest
 BuildRequires: cyrus-sasl-plain
 BuildRequires: openssl
+# check python linters
+BuildRequires: python3-flake8
+BuildRequires: pylint
+BuildRequires: python3-mypy
 
 # proton-c requirements
 BuildRequires: openssl-devel
@@ -100,6 +107,7 @@ cd %{_builddir}/qpid-proton-%{proton_vendored_version}
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_TESTING=OFF \
     -DBUILD_BINDINGS=OFF \
+    -DPython_EXECUTABLE=%{python3} \
     -DBUILD_TLS=ON -DSSL_IMPL=openssl \
     -DBUILD_STATIC_LIBS=ON \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
@@ -119,6 +127,9 @@ cd %{_builddir}/skupper-router-%{version}
 %install
 cd %{_builddir}/skupper-router-%{version}
 %cmake_install
+
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#py3_shebang_fix
+%py3_shebang_fix %{buildroot}/%{_bindir}/skmanage %{buildroot}/%{_bindir}/skstat
 
 %check
 cd %{_builddir}/skupper-router-%{version}


### PR DESCRIPTION
Currently, sandboxed RPM build fails when `pip install` tries to fetch wheel from pip.

This change installs wheel beforehand, so it is detected and install is skipped.