### PR TITLE
Fixes #151: Send messages only when there is credit to send instead o…

### DIFF
--- a/tests/system_tests_delivery_counts.py
+++ b/tests/system_tests_delivery_counts.py
@@ -980,7 +980,6 @@ class OneRouterLinkCountersTest(TestCase):
                 self.poll_timer_started = True
                 self.poll_timer = event.reactor.schedule(0.5, PollTimeout(self))
 
-
     def verify_released(self, large_message=False):
         """
         Verify the link released count by releasing all received messages


### PR DESCRIPTION
…f sending all messages in one single loop. This makes sure that we are not exhausting credit inside the send loop