### PR TITLE
NO-ISSUE: update `.clang-format` options to be less annoying

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,11 +34,15 @@ PointerAlignment: Right
 SpaceAroundPointerQualifiers: Both
 BreakBeforeBinaryOperators: NonAssignment
 SpaceAfterCStyleCast: true
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true
-AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: AcrossComments
+AlignConsecutiveDeclarations: AcrossComments
+AlignConsecutiveMacros: AcrossComments
 KeepEmptyLinesAtTheStartOfBlocks: false
 ExperimentalAutoDetectBinPacking: true
+AlignTrailingComments:
+  Kind: Leave
+SeparateDefinitionBlocks: Leave
+MaxEmptyLinesToKeep: 3
 
 IncludeCategories:
   # python-related headers must go first


### PR DESCRIPTION
Having closed

* https://github.com/skupperproject/skupper-router/issues/661

as a won't-do, this is a small attempt to make `clang-format` a bit more useful.