### PR TITLE
Fixes #1298: use entropy pool to generate PRNG seed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,6 +186,7 @@ target_link_libraries(skupper-router PUBLIC ${qpid_dispatch_LIBRARIES})
 
 # check for various function availability
 check_symbol_exists(getrlimit sys/resource.h QD_HAVE_GETRLIMIT)
+check_symbol_exists(getrandom sys/random.h QD_HAVE_GETRANDOM)
 
 # https://stackoverflow.com/questions/54771452/expanding-a-variable-cmakedefine-and-generator-expression-in-template-file
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/config.h.in" CONFIG_H_IN)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -22,4 +22,5 @@
 #define QPID_DISPATCH_VERSION "${QPID_DISPATCH_VERSION}"
 #define QPID_DISPATCH_HTTP_ROOT_DIR "${QPID_DISPATCH_HTML_DIR}"
 #cmakedefine01 QD_HAVE_GETRLIMIT
+#cmakedefine01 QD_HAVE_GETRANDOM
 #endif // __src_config_h_in__


### PR DESCRIPTION
If entropy pool not available use a nano-second clock and process id to generate the seed value.

(cherry picked from commit f25fffe96c9431bb7c528b0288369e1962a89784)