### PR TITLE
NO-ISSUE: fix skupper-router.spec to get a green packit build (excluding flakes)

### DIFF
--- a/packaging/skupper-router.spec
+++ b/packaging/skupper-router.spec
@@ -136,7 +136,7 @@ cd %{_builddir}/skupper-router-%{version}
 # Python 3.12 considers emtpy test suite a failure, and the following suites skip all tests due to missing reqs:
 #  test_stopping_broker_while_websocket_is_connected_does_not_crash (system_tests_websockets.WebsocketsConsoleTest.test_stopping_broker_while_websocket_is_connected_does_not_crash) ... skipped 'python test requirement package `websockets` is missing'
 #  test_grpc_01_unary (system_tests_grpc.GrpcServiceMethodsTest.test_grpc_01_unary) ... skipped 'grpcio is needed to run grpc tests'
-%ctest -E '^(system_tests_grpc|system_tests_websockets)$'
+%ctest --exclude-regex '^(system_tests_grpc|system_tests_websockets)$'
 
 %files
 /usr/sbin/skrouterd

--- a/packaging/skupper-router.spec
+++ b/packaging/skupper-router.spec
@@ -133,7 +133,10 @@ cd %{_builddir}/skupper-router-%{version}
 
 %check
 cd %{_builddir}/skupper-router-%{version}
-%ctest
+# Python 3.12 considers emtpy test suite a failure, and the following suites skip all tests due to missing reqs:
+#  test_stopping_broker_while_websocket_is_connected_does_not_crash (system_tests_websockets.WebsocketsConsoleTest.test_stopping_broker_while_websocket_is_connected_does_not_crash) ... skipped 'python test requirement package `websockets` is missing'
+#  test_grpc_01_unary (system_tests_grpc.GrpcServiceMethodsTest.test_grpc_01_unary) ... skipped 'grpcio is needed to run grpc tests'
+%ctest -E '^(system_tests_grpc|system_tests_websockets)$'
 
 %files
 /usr/sbin/skrouterd


### PR DESCRIPTION
Python 3.12 used on Fedora 39 changed handling of empty test suites. Previously, empty suite resulted in PASS but now it is a FAIL.