### PR TITLE
Fixes #1363: add missing <sys/time.h> header, it is masked by Python <3.13 includes which now pull it in

### DIFF
--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -21,24 +21,25 @@
 
 #include "qpid/dispatch/alloc_pool.h"
 
+#include "aprintf.h"
 #include "config.h"
 #include "entity.h"
 #include "entity_cache.h"
 #include "http.h"
 #include "qd_asan_interface.h"
-#include "aprintf.h"
 
 #include "qpid/dispatch/alloc.h"
 #include "qpid/dispatch/ctools.h"
 #include "qpid/dispatch/log.h"
-#include "qpid/dispatch/timer.h"
 #include "qpid/dispatch/platform.h"
+#include "qpid/dispatch/timer.h"
 
 #include "proton/version.h"
 
 #include <inttypes.h>
 #include <memory.h>
 #include <stdio.h>
+#include <sys/time.h>
 
 #ifdef QD_MEMORY_DEBUG
 #include "log_private.h"

--- a/src/log.c
+++ b/src/log.c
@@ -38,6 +38,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/time.h>
 #include <syslog.h>
 
 #define TEXT_MAX QD_LOG_TEXT_MAX


### PR DESCRIPTION
Fixes #1363