### PR TITLE
Revert "Issue #1367: Build arm64/v2 (aarch64) skupper-router docker image"

### DIFF
--- a/.github/scripts/compile.sh
+++ b/.github/scripts/compile.sh
@@ -22,31 +22,8 @@
 # https://sipb.mit.edu/doc/safe-shell
 set -Eefuxo pipefail
 
-if [[ -n "${TARGETPLATFORM:-}" && -n "${BUILDPLATFORM:-}" && "${TARGETPLATFORM}" != "${BUILDPLATFORM}" ]]; then
-  CROSSCOMPILING=true
-else
-  CROSSCOMPILING=false
-fi
-
-if [[ "${CROSSCOMPILING}" == true ]]; then
-  ENABLE_PROFILE_GUIDED_OPTIMIZATION=OFF
-
-  microdnf install -y tar xz
-  curl -L https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz | tar -xJ --directory=/usr/local/bin --strip-components=1
-
-  # create compiler tools startup scripts, with llvm- prefix so that CMake finds it
-  echo -e '#!/bin/bash\nzig ar "$@"' > /usr/local/bin/llvm-ar
-  echo -e '#!/bin/bash\nzig ranlib "$@"' > /usr/local/bin/llvm-ranlib
-  chmod +x /usr/local/bin/llvm-ar /usr/local/bin/llvm-ranlib
-
-  export CC='zig cc -target aarch64-linux-gnu.2.34 --sysroot / -isystem /usr/include -L/usr/lib64 -isystem /usr/local/include -L/usr/local/lib64'
-  export CXX='zig c++ -target aarch64-linux-gnu.2.34 --sysroot / -isystem /usr/include -L/usr/lib64 -isystem /usr/local/include -L/usr/local/lib64'
-else
-  ENABLE_PROFILE_GUIDED_OPTIMIZATION=ON
-
-  BUILD_FLAGS="$(rpmbuild --undefine _annotated_build --eval '%set_build_flags')"
-  eval "${BUILD_FLAGS}"
-fi
+BUILD_FLAGS="$(rpmbuild --undefine _annotated_build --eval '%set_build_flags')"
+eval "${BUILD_FLAGS}"
 
 if [ -z "${REMOTE_SOURCES_DIR:-}" ]; then
   # If no REMOTE_SOURCES_DIR present in env, we use $(pwd) as working dir
@@ -129,7 +106,7 @@ tar -z -C "${LWS_INSTALL_DIR}" -cf /libwebsockets-image.tar.gz usr
 pushd "${LIBUNWIND_DIR}"
 autoreconf -i
 ./configure
-make install -j "$(nproc)"
+make install
 DESTDIR="${LIBUNWIND_INSTALL_DIR}" make install
 tar -z -C "${LIBUNWIND_INSTALL_DIR}" -cf /libunwind-image.tar.gz usr
 popd
@@ -149,10 +126,8 @@ do_patch () {
 
 do_patch "patches/proton" "${PROTON_DIR}"
 
-if [[ "${ENABLE_PROFILE_GUIDED_OPTIMIZATION}" == true ]]; then
-  # This is required to install the python packages that the system tests use.
-  python3 -m pip install -r "${SKUPPER_DIR}"/requirements-dev.txt
-fi
+# This is required to install the python packages that the system tests use.
+python3 -m pip install -r "${SKUPPER_DIR}"/requirements-dev.txt
 
 cmake -S "${PROTON_DIR}" -B "${PROTON_BUILD_DIR}" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -162,7 +137,7 @@ cmake -S "${PROTON_DIR}" -B "${PROTON_BUILD_DIR}" \
   -DBUILD_TOOLS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
   -DCMAKE_INSTALL_PREFIX=${PROTON_BUILD_DIR}/install
 
-cmake --build "${PROTON_BUILD_DIR}" --parallel "$(nproc)" --verbose
+cmake --build "${PROTON_BUILD_DIR}" --verbose
 
 # `cmake --install` Proton for the build image only as the router links it statically
 # Proton Python for the run image is installed later
@@ -176,11 +151,10 @@ cmake -S "${SKUPPER_DIR}" -B "${SKUPPER_BUILD_DIR}" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DProton_USE_STATIC_LIBS=ON \
   -DProton_DIR="${PROTON_BUILD_DIR}/install/lib64/cmake/Proton" \
-  -DENABLE_PROFILE_GUIDED_OPTIMIZATION=${ENABLE_PROFILE_GUIDED_OPTIMIZATION} \
-  -DBUILD_TESTING=${ENABLE_PROFILE_GUIDED_OPTIMIZATION} \
+  -DENABLE_PROFILE_GUIDED_OPTIMIZATION=ON \
   -DVERSION="${VERSION}" \
   -DCMAKE_INSTALL_PREFIX=/usr
-cmake --build "${SKUPPER_BUILD_DIR}" --parallel "$(nproc)" --verbose
+cmake --build "${SKUPPER_BUILD_DIR}" --verbose
 
 # Install Proton Python
 python3 -m pip install --disable-pip-version-check --ignore-installed --prefix="$PROTON_INSTALL_DIR/usr" "$(find "$PROTON_BUILD_DIR/python/" -name 'python-qpid-proton-*.tar.gz')"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -889,15 +889,10 @@ jobs:
         run: cmake --build "${RouterBuildDir}" --config ${BuildType} --target install --parallel 6
 
   container:
-    name: Container image (${{ matrix.platform }})
+    name: Container image
     runs-on: ubuntu-latest
     env:
       ImageName: local/skupper-router:local
-    strategy:
-      fail-fast: false
-      matrix:
-        # https://github.com/containerd/containerd/blob/v1.7.1/platforms/platforms.go#L63
-        platform: ['linux/amd64', 'linux/arm64/v8']
 
     steps:
 
@@ -917,14 +912,9 @@ jobs:
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
 
-      - name: Enable qemu to build foreign architectures
-        if: matrix.platform != 'linux/amd64'
-        run: sudo podman run --privileged --rm docker.io/tonistiigi/binfmt --install all
-
       - name: Build Containerfile
         run: |
-          export BUILDAH_FORMAT=docker
-          podman buildx build --platform=${{ matrix.platform }} -t ${{ env.ImageName }} -f ./Containerfile .
+          podman build -t ${{ env.ImageName }} -f ./Containerfile .
 
       # When rustup is updated, it tries to replace its binary, which on Windows is somehow locked.
       # This can result in a CI failure, see: https://github.com/rust-lang/rustup/issues/3029

--- a/.github/workflows/image-main.yml
+++ b/.github/workflows/image-main.yml
@@ -37,7 +37,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             ${{ github.event.workflow_run.jobs_url }} > jobs.json
 
-          conclusion=$(jq < jobs.json --raw-output '.jobs[] |  select( .name == "Container image (linux/amd64)") | .conclusion')
+          conclusion=$(jq < jobs.json --raw-output '.jobs[] |  select( .name == "Container image") | .conclusion')
           echo ${conclusion}
 
           [[ ${conclusion} == "success" ]]
@@ -46,8 +46,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
+        if: ${{ !cancelled() }}
 
       - name: Build and publish the main image
+        if: ${{ !cancelled() }}
         run: |
           # The version on main will be 0.0.0+<commit-sha>-main
           export VERSION="0.0.0+${GITHUB_SHA}-main"

--- a/Containerfile
+++ b/Containerfile
@@ -17,12 +17,7 @@
 # under the License.
 #
 
-# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
-# $TARGETPLATFORM, ... requires podman 4.2 (https://github.com/containers/podman/issues/14375)
-
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:latest as builder
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as builder
 
 RUN microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
     rpm-build \
@@ -49,7 +44,7 @@ ENV VERSION=$VERSION
 RUN .github/scripts/compile.sh
 RUN tar zxpf /qpid-proton-image.tar.gz --one-top-level=/image && tar zxpf /skupper-router-image.tar.gz --one-top-level=/image && tar zxpf /libwebsockets-image.tar.gz --one-top-level=/image && tar zxpf /libunwind-image.tar.gz --one-top-level=/image
 
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 RUN microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
     glibc \

--- a/router/CMakeLists.txt
+++ b/router/CMakeLists.txt
@@ -31,17 +31,10 @@ set(router_SOURCES
     src/panic.c
     )
 
-include(CheckLinkerFlag)
-check_linker_flag(C "LINKER:-Map=skrouterd.map" linker_map_supported)
-
 add_executable(skrouterd ${router_SOURCES})
 target_include_directories(skrouterd PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(skrouterd PRIVATE skupper-router)
-if (linker_map_supported)
-    target_link_options(skrouterd PUBLIC LINKER:-Map=skrouterd.map)
-else ()
-    message(WARNING "Linker map generation not supported, skrouterd.map will not be written out")
-endif ()
+target_link_options(skrouterd PUBLIC LINKER:-Map=skrouterd.map)
 
 if (ENABLE_PROFILE_GUIDED_OPTIMIZATION)
     if("GNU" STREQUAL ${CMAKE_C_COMPILER_ID})


### PR DESCRIPTION
Since we've decided we don't want to cross-compile with zig for arm64, let's again remove the code added to support it.

Zig compilation fails with libunwind 1.8.0 as whitnessed by @ganeshmurthy .

* Reverts skupperproject/skupper-router#1100