### PR TITLE
NO-ISSUE: Run microdnf upgrade in image builds to resolve fixable vulnerable dependencies

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,6 +19,11 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as builder
 
+# upgrade first to avoid fixable vulnerabilities
+# do this in builder as well as in buildee, so builder does not have different pkg versions from buildee image
+RUN microdnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+ && microdnf clean all -y
+
 RUN microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
     rpm-build \
     gcc gcc-c++ make cmake pkgconfig \
@@ -45,6 +50,10 @@ RUN .github/scripts/compile.sh
 RUN tar zxpf /qpid-proton-image.tar.gz --one-top-level=/image && tar zxpf /skupper-router-image.tar.gz --one-top-level=/image && tar zxpf /libwebsockets-image.tar.gz --one-top-level=/image && tar zxpf /libunwind-image.tar.gz --one-top-level=/image
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+# upgrade first to avoid fixable vulnerabilities
+RUN microdnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+ && microdnf clean all -y
 
 RUN microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
     glibc \


### PR DESCRIPTION
The update/upgrade command in dnf has flags `--security` and `--secseverity=Moderate`.

Since `microdnf` does not have this sophisticated handling, and installing full `dnf` is by itself increasing the cve exposure surface significantly, we need to do with some restrictive set of flags of `microdnf` to make it update what it can, but no more.

What's in the commit is stolen from
https://stackoverflow.com/questions/61662403/microdnf-update-command-installs-new-packages-instead-of-just-updating-existing.