### PR TITLE
Fixes #1398, #1405 - bugs involving deletion of tcpConnector/Listeners

### DIFF
--- a/src/adaptors/adaptor_common.c
+++ b/src/adaptors/adaptor_common.c
@@ -245,17 +245,37 @@ int qd_raw_connection_write_buffers(pn_raw_connection_t *pn_raw_conn, qd_adaptor
     return num_buffers_written;
 }
 
+
+size_t qd_raw_conn_get_address_buf(pn_raw_connection_t *pn_raw_conn, char *buf, size_t buflen)
+{
+    assert(pn_raw_conn);
+    assert(buflen);
+
+    buf[0] = '\0';
+
+    const pn_netaddr_t *netaddr = pn_raw_connection_remote_addr(pn_raw_conn);
+    if (!netaddr)
+        return 0;
+
+    int len = pn_netaddr_str(netaddr, buf, buflen);
+    if (len < 0)
+        return 0;
+    if (len >= buflen) {  // truncated
+        len = buflen - 1;
+        buf[len] = '\0';
+    }
+
+    return (size_t) len;
+}
+
+
 char *qd_raw_conn_get_address(pn_raw_connection_t *pn_raw_conn)
 {
-    const pn_netaddr_t *netaddr = pn_raw_connection_remote_addr(pn_raw_conn);
-    char                buffer[1024];
-    int                 len = pn_netaddr_str(netaddr, buffer, 1024);
-    if (len <= 1024) {
-        return strdup(buffer);
-    } else {
-        return strndup(buffer, 1024);
-    }
+    char result[1024];
+    qd_raw_conn_get_address_buf(pn_raw_conn, result, sizeof(result));
+    return strdup(result);
 }
+
 
 int qd_raw_connection_drain_write_buffers(pn_raw_connection_t *pn_raw_conn)
 {

--- a/src/adaptors/adaptor_common.h
+++ b/src/adaptors/adaptor_common.h
@@ -96,6 +96,13 @@ int qd_raw_connection_write_buffers(pn_raw_connection_t *pn_raw_conn, qd_adaptor
 char *qd_raw_conn_get_address(pn_raw_connection_t *pn_raw_conn);
 
 /**
+ * Get the raw connections remote address.
+ * Like qd_raw_conn_get_address(), but address buffer is supplied by caller.
+ * @return number of bytes written, zero if no address available (buf is set to the null string).
+ */
+size_t qd_raw_conn_get_address_buf(pn_raw_connection_t *pn_raw_conn, char *buf, size_t buflen);
+
+/**
  * Drains write buffers held by proton raw connection.
  * @param raw_conn - The pn_raw_connection_t to which the write buffers were granted.
  */

--- a/src/adaptors/tcp_lite/tcp_lite.c
+++ b/src/adaptors/tcp_lite/tcp_lite.c
@@ -180,13 +180,13 @@ static pn_data_t *TL_conn_properties(void)
 }
 
 
-static qdr_connection_t *TL_open_core_connection(uint64_t conn_id, bool incoming)
+static qdr_connection_t *TL_open_core_connection(uint64_t conn_id, bool incoming, const char *host)
 {
     qdr_connection_t *conn;
-    
+
     //
     // The qdr_connection_info() function makes its own copy of the passed in tcp_conn_properties.
-    // So, we need to call pn_data_free(tcp_conn_properties)
+    // So, we need to call pn_data_free(properties)
     //
     pn_data_t *properties       = TL_conn_properties();
     qdr_connection_info_t *info = qdr_connection_info(false,        // is_encrypted,
@@ -194,7 +194,7 @@ static qdr_connection_t *TL_open_core_connection(uint64_t conn_id, bool incoming
                                                       true,         // opened,
                                                       "",           // sasl_mechanisms,
                                                       incoming ? QD_INCOMING : QD_OUTGOING,  // dir,
-                                                      "tcplite",    // host,
+                                                      host,
                                                       "",           // ssl_proto,
                                                       "",           // ssl_cipher,
                                                       "",           // user,
@@ -266,8 +266,9 @@ static void TL_setup_connector(tcplite_connector_t *cr)
     // Set up a core connection to handle all of the links and deliveries for this connector
     //
     cr->conn_id   = qd_server_allocate_connection_id(tcplite_context->server);
-    cr->core_conn = TL_open_core_connection(cr->conn_id, false);
+    cr->core_conn = TL_open_core_connection(cr->conn_id, false, "egress-dispatch");
     qdr_connection_set_context(cr->core_conn, cr);
+    cr->connections_opened = 1;  // for legacy compatibility: it counted the egress-dispatch conn
 
     //
     // Attach an out-link to represent our desire to receive connection streams for the address
@@ -759,11 +760,13 @@ static void link_setup_LSIDE_IO(tcplite_connection_t *conn)
     tcplite_listener_t *li = (tcplite_listener_t*) conn->common.parent;
     qdr_terminus_t *target = qdr_terminus(0);
     qdr_terminus_t *source = qdr_terminus(0);
+    char host[64];  // for numeric remote client IP:port address
 
     qdr_terminus_set_address(target, li->adaptor_config->address);
     qdr_terminus_set_dynamic(source);
-    
-    conn->core_conn = TL_open_core_connection(conn->conn_id, true);
+
+    qd_raw_conn_get_address_buf(conn->raw_conn, host, sizeof(host));
+    conn->core_conn = TL_open_core_connection(conn->conn_id, true, host);
     qdr_connection_set_context(conn->core_conn, conn);
 
     conn->inbound_link = qdr_link_first_attach(conn->core_conn, QD_INCOMING, qdr_terminus(0), target, "tcp.lside.in", 0, false, 0, &conn->inbound_link_id);
@@ -779,10 +782,12 @@ static void link_setup_CSIDE_IO(tcplite_connection_t *conn, qdr_delivery_t *deli
 {
     ASSERT_RAW_IO;
     qdr_terminus_t *target = qdr_terminus(0);
+    char host[64];  // for numeric remote server IP:port address
 
     qdr_terminus_set_address(target, conn->reply_to);
 
-    conn->core_conn = TL_open_core_connection(conn->conn_id, false);
+    qd_raw_conn_get_address_buf(conn->raw_conn, host, sizeof(host));
+    conn->core_conn = TL_open_core_connection(conn->conn_id, false, host);
     qdr_connection_set_context(conn->core_conn, conn);
 
     conn->inbound_link = qdr_link_first_attach(conn->core_conn, QD_INCOMING, qdr_terminus(0), target, "tcp.cside.in", 0, false, 0, &conn->inbound_link_id);
@@ -1781,12 +1786,15 @@ void qd_dispatch_delete_tcp_listener_lite(qd_dispatch_t *qd, tcplite_listener_t 
     if (li) {
         li->closing = true;
 
-        if (!tcplite_context->adaptor_finalizing) {
-            if (!!li->adaptor_listener) {
-                qd_adaptor_listener_close(li->adaptor_listener);
-                li->adaptor_listener = 0;
-            }
-        } else {
+        // deactivate the listener to prevent new connections from being accepted
+        // on the proactor thread
+        //
+        if (!!li->adaptor_listener) {
+            qd_adaptor_listener_close(li->adaptor_listener);
+            li->adaptor_listener = 0;
+        }
+
+        if (tcplite_context->adaptor_finalizing) {
             tcplite_connection_t *conn = DEQ_HEAD(li->connections);
             if (!!conn) {
                 while (conn) {
@@ -1874,6 +1882,15 @@ void qd_dispatch_delete_tcp_connector_lite(qd_dispatch_t *qd, tcplite_connector_
     SET_THREAD_UNKNOWN;
     if (cr) {
         cr->closing = true;
+
+        // Explicitly drop the out-link so that we notify any link event monitors and stop new deliveries from being
+        // forwarded to this connector
+        //
+        if (!!cr->out_link) {
+            qdr_link_set_context(cr->out_link, 0);
+            qdr_link_detach(cr->out_link, QD_LOST, 0);
+            cr->out_link = 0;
+        }
 
         if (!tcplite_context->adaptor_finalizing) {
             qdr_connection_closed(cr->core_conn);

--- a/src/adaptors/tcp_lite/tcp_lite.h
+++ b/src/adaptors/tcp_lite/tcp_lite.h
@@ -59,8 +59,6 @@ struct tcplite_listener_t {
     sys_mutex_t                lock;
     qd_adaptor_config_t       *adaptor_config;
     qd_tls_domain_t           *tls_domain;
-    uint64_t                   link_id;
-    qdr_link_t                *in_link;
     qd_adaptor_listener_t     *adaptor_listener;
     tcplite_connection_list_t  connections;
     qdpo_config_t             *protocol_observer_config;


### PR DESCRIPTION
TCP adaptor creates special connection instances that are used for managing the service address subscriptions. A user must not inadvertantly delete these connections or the router will malfunction. This patch prevents these connections from being force-closed via the management interface.

This patch also fixes a bug where a stale route entry for the service address was not cleaned up after the tcpConnector is deleted.

Closes #1398
Closes #1405