### PR TITLE
Fix pulling of `summerwind/h2spec:2.6.0` image in tests

### DIFF
--- a/tests/testcontainers/docker.rs
+++ b/tests/testcontainers/docker.rs
@@ -37,7 +37,7 @@ use tokio::task::JoinHandle;
 const DRAIN_LOGS_TIMEOUT: Duration = Duration::from_secs(5);
 
 // https://hub.docker.com/r/summerwind/h2spec
-pub(crate) const H2SPEC_IMAGE: &str = "summerwind/h2spec:2.6.0";  // do not prefix with `docker.io/`, docker won't find it
+pub(crate) const H2SPEC_IMAGE: &str = "docker.io/summerwind/h2spec:2.6.0";  // do not prefix with `docker.io/` for docker; podman does not mind
 // https://nixery.dev/
 pub(crate) const NGHTTP2_IMAGE: &str = "nixery.dev/nghttp2:latest";
 pub(crate) const NETCAT_IMAGE: &str = "nixery.dev/netcat:latest";


### PR DESCRIPTION
```
called `Result::unwrap()` on an `Err` value: DockerStreamError { error: "2 errors occurred while pulling:\n * reading blob sha256:c507fbd6f6f21c5c0dd2092c8690a067bfd43bcbe4da7fc2f05748578d066d66: Error fetching blob: invalid status code from registry 503 (Service Unavailable)\n * initializing source docker://[quay.io/summerwind/h2spec:2.6.0](http://quay.io/summerwind/h2spec:2.6.0): reading manifest 2.6.0 in [quay.io/summerwind/h2spec](http://quay.io/summerwind/h2spec): unauthorized: access to the requested resource is not authorized" }
```