### PR TITLE
Fixes #1435 - MNI (Multi-network-interior)

### DIFF
--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -46,7 +46,7 @@ ENUM_DECLARE(qd_router_mode);
 /**
  * Allocate and start an instance of the router core module.
  */
-qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area, const char *id);
+qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area, const char *id, const char *van_id);
 
 /**
  * Stop and deallocate an instance of the router core.
@@ -67,7 +67,7 @@ qd_dispatch_t *qdr_core_dispatch(qdr_core_t *core);
 /**
  * Drive the core-internal timer every one second.
  *
- * @param core Pointer to the core object returned by qd_core()
+ * @param core Pointer to the core object returned by qdr_core()
  */
 void qdr_process_tick(qdr_core_t *core);
 
@@ -78,6 +78,15 @@ void qdr_process_tick(qdr_core_t *core);
  * @return count of worker threads
  */
 int qdr_core_get_worker_thread_count(const qdr_core_t *core);
+
+/**
+ * @brief Return the text of the router's virtual application network ID, or 0.
+ *
+ * @param core Pointer to the core object returned by qdr_core()
+ * @return const char* null-terminated text of the van-id or 0 if there's no id.
+ */
+const char *qdr_core_van_id(const qdr_core_t *core);
+
 
 /**
  ******************************************************************************

--- a/python/skupper_router/management/skrouter.json
+++ b/python/skupper_router/management/skrouter.json
@@ -379,6 +379,12 @@
                     "required": false,
                     "create": true
                 },
+                "vanId": {
+                    "description":"The unique ID of the Virtual Application Network that this router is a member of.",
+                    "type": "string",
+                    "required": false,
+                    "create": true
+                },
                 "mode": {
                     "type": [
                         "standalone",

--- a/src/adaptors/adaptor_common.h
+++ b/src/adaptors/adaptor_common.h
@@ -29,6 +29,7 @@
 #include "qpid/dispatch/log.h"
 #include "qpid/dispatch/threading.h"
 #include "qpid/dispatch/vanflow.h"
+#include "qpid/dispatch/router_core.h"
 
 #include <proton/raw_connection.h>
 #include <proton/tls.h>
@@ -65,7 +66,7 @@ struct qd_adaptor_config_t
 
 ALLOC_DECLARE(qd_adaptor_config_t);
 
-qd_error_t qd_load_adaptor_config(qd_adaptor_config_t *config, qd_entity_t *entity);
+qd_error_t qd_load_adaptor_config(qdr_core_t *core, qd_adaptor_config_t *config, qd_entity_t *entity);
 void qd_free_adaptor_config(qd_adaptor_config_t *config);
 
 /**

--- a/src/adaptors/http_common.c
+++ b/src/adaptors/http_common.c
@@ -74,13 +74,13 @@ static void qd_free_http_adaptor_config(qd_http_adaptor_config_t *config)
     free_qd_http_adaptor_config_t(config);
 }
 
-static qd_error_t qd_load_http_adaptor_config(qd_http_adaptor_config_t *config, qd_entity_t *entity)
+static qd_error_t qd_load_http_adaptor_config(qdr_core_t *core, qd_http_adaptor_config_t *config, qd_entity_t *entity)
 {
     assert(config);
     //
     // First load the common config data (common to all adaptors)
     //
-    qd_error_t qd_error = qd_load_adaptor_config(config->adaptor_config, entity);
+    qd_error_t qd_error = qd_load_adaptor_config(core, config->adaptor_config, entity);
     if (qd_error != QD_ERROR_NONE) {
         return qd_error;
     }
@@ -133,7 +133,7 @@ qd_http_listener_t *qd_dispatch_configure_http_listener(qd_dispatch_t *qd, qd_en
     qd_http_listener_t *listener = qd_http_listener(qd->server);
     assert(listener);
 
-    if (qd_load_http_adaptor_config(listener->config, entity) != QD_ERROR_NONE) {
+    if (qd_load_http_adaptor_config(qd->router->router_core, listener->config, entity) != QD_ERROR_NONE) {
         qd_log(LOG_HTTP_ADAPTOR, QD_LOG_ERROR, "Unable to configure a new httpListener: %s",
                qd_error_message());
         qd_http_listener_decref(listener);
@@ -197,7 +197,7 @@ qd_http_connector_t *qd_dispatch_configure_http_connector(qd_dispatch_t *qd, qd_
     qd_http_connector_t *conn = qd_http_connector(qd->server);
     assert(conn);
 
-    if (qd_load_http_adaptor_config(conn->config, entity) != QD_ERROR_NONE) {
+    if (qd_load_http_adaptor_config(qd->router->router_core, conn->config, entity) != QD_ERROR_NONE) {
         qd_log(LOG_HTTP_ADAPTOR, QD_LOG_ERROR, "Unable to configure a new httpConnector: %s",
                qd_error_message());
         qd_http_connector_decref(conn);

--- a/src/adaptors/tcp/tcp_adaptor.c
+++ b/src/adaptors/tcp/tcp_adaptor.c
@@ -1581,10 +1581,10 @@ static qd_tcp_listener_t *qd_tcp_listener(qd_server_t *server)
     return li;
 }
 
-static qd_error_t qd_load_tcp_adaptor_config(qd_tcp_adaptor_config_t *config, qd_entity_t *entity)
+static qd_error_t qd_load_tcp_adaptor_config(qdr_core_t *core, qd_tcp_adaptor_config_t *config, qd_entity_t *entity)
 {
     // Make a call to the function that loads the common adaptor config.
-    qd_error_t qd_error = qd_load_adaptor_config(config->adaptor_config, entity);
+    qd_error_t qd_error = qd_load_adaptor_config(core, config->adaptor_config, entity);
     // Add more code here if you want to load something specific to the tcp adaptor config.
     return qd_error;
 }
@@ -1594,7 +1594,7 @@ static qd_error_t qd_load_tcp_adaptor_config(qd_tcp_adaptor_config_t *config, qd
 qd_tcp_listener_t *qd_dispatch_configure_tcp_listener_legacy(qd_dispatch_t *qd, qd_entity_t *entity)
 {
     qd_tcp_listener_t *li = qd_tcp_listener(qd->server);
-    if (qd_load_tcp_adaptor_config(li->config, entity) != QD_ERROR_NONE) {
+    if (qd_load_tcp_adaptor_config(qd->router->router_core, li->config, entity) != QD_ERROR_NONE) {
         qd_log(LOG_TCP_ADAPTOR, QD_LOG_ERROR, "Unable to create tcp listener: %s", qd_error_message());
         qd_tcp_listener_decref(li);
         return 0;
@@ -1715,7 +1715,7 @@ static void qd_tcp_connector_decref(qd_tcp_connector_t* c)
 qd_tcp_connector_t *qd_dispatch_configure_tcp_connector_legacy(qd_dispatch_t *qd, qd_entity_t *entity)
 {
     qd_tcp_connector_t *c = qd_tcp_connector(qd->server);
-    if (qd_load_tcp_adaptor_config(c->config, entity) != QD_ERROR_NONE) {
+    if (qd_load_tcp_adaptor_config(qd->router->router_core, c->config, entity) != QD_ERROR_NONE) {
         qd_log(LOG_TCP_ADAPTOR, QD_LOG_ERROR, "Unable to create tcp connector: %s", qd_error_message());
         qd_tcp_connector_decref(c);
         return 0;

--- a/src/adaptors/tcp_lite/tcp_lite.c
+++ b/src/adaptors/tcp_lite/tcp_lite.c
@@ -2226,7 +2226,7 @@ tcplite_listener_t *qd_dispatch_configure_tcp_listener_lite(qd_dispatch_t *qd, q
 
     li->adaptor_config = new_qd_adaptor_config_t();
 
-    if (qd_load_adaptor_config(li->adaptor_config, entity) != QD_ERROR_NONE) {
+    if (qd_load_adaptor_config(tcplite_context->core, li->adaptor_config, entity) != QD_ERROR_NONE) {
         qd_log(LOG_TCP_ADAPTOR, QD_LOG_ERROR, "Unable to create tcp listener: %s", qd_error_message());
         qd_free_adaptor_config(li->adaptor_config);
         free_tcplite_listener_t(li);
@@ -2339,7 +2339,7 @@ tcplite_connector_t *qd_dispatch_configure_tcp_connector_lite(qd_dispatch_t *qd,
 
     cr->adaptor_config = new_qd_adaptor_config_t();
 
-    if (qd_load_adaptor_config(cr->adaptor_config, entity) != QD_ERROR_NONE) {
+    if (qd_load_adaptor_config(tcplite_context->core, cr->adaptor_config, entity) != QD_ERROR_NONE) {
         qd_log(LOG_TCP_ADAPTOR, QD_LOG_ERROR, "Unable to create tcp connector: %s", qd_error_message());
         qd_free_adaptor_config(cr->adaptor_config);
         free_tcplite_connector_t(cr);

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -59,6 +59,7 @@ void            qd_router_free(qd_router_t *router);
 void            qd_error_initialize(void);
 static void qd_dispatch_set_router_id(qd_dispatch_t *qd, char *_id);
 static void qd_dispatch_set_router_area(qd_dispatch_t *qd, char *_area);
+static void qd_dispatch_set_router_van_id(qd_dispatch_t *qd, char *_van_id);
 static void qd_dispatch_policy_c_counts_free(PyObject *capsule);
 
 const char     *CLOSEST_DISTRIBUTION   = "closest";
@@ -220,6 +221,7 @@ qd_error_t qd_dispatch_configure_router(qd_dispatch_t *qd, qd_entity_t *entity)
 {
     qd_dispatch_set_router_default_distribution(qd, qd_entity_opt_string(entity, "defaultDistribution", 0)); QD_ERROR_RET();
     qd_dispatch_set_router_id(qd, qd_entity_opt_string(entity, "id", 0)); QD_ERROR_RET();
+    qd_dispatch_set_router_van_id(qd, qd_entity_opt_string(entity, "vanId", 0)); QD_ERROR_RET();
     qd->router_mode = qd_entity_get_long(entity, "mode"); QD_ERROR_RET();
     if (!qd->router_id) {
         char *mode = 0;
@@ -369,6 +371,14 @@ static void qd_dispatch_set_router_area(qd_dispatch_t *qd, char *_area) {
     qd->router_area = _area;
 }
 
+// Takes ownership of _van_id
+static void qd_dispatch_set_router_van_id(qd_dispatch_t *qd, char *_van_id) {
+    if (qd->van_id) {
+        free(qd->van_id);
+    }
+    qd->van_id = _van_id;
+}
+
 void qd_dispatch_free(qd_dispatch_t *qd)
 {
     if (!qd) return;
@@ -390,6 +400,7 @@ void qd_dispatch_free(qd_dispatch_t *qd)
     qd_python_finalize();
     qd_dispatch_set_router_id(qd, NULL);
     qd_dispatch_set_router_area(qd, NULL);
+    qd_dispatch_set_router_van_id(qd, NULL);
     qd_iterator_finalize();
     free(qd->timestamp_format);
     free(qd->metadata);

--- a/src/dispatch_private.h
+++ b/src/dispatch_private.h
@@ -56,6 +56,7 @@ struct qd_dispatch_t {
     char  *router_area;
     char  *router_id;
     qd_router_mode_t router_mode;
+    char  *van_id;
     char  *timestamp_format;
     char  *metadata;
     bool   timestamps_in_utc;

--- a/src/router_core/agent_router.c
+++ b/src/router_core/agent_router.c
@@ -31,34 +31,35 @@
 #define QDR_ROUTER_TYPE                                3
 #define QDR_ROUTER_MODE                                4
 #define QDR_ROUTER_AREA                                5
-#define QDR_ROUTER_VERSION                             6
-#define QDR_ROUTER_METADATA                            7
-#define QDR_ROUTER_ADDR_COUNT                          8
-#define QDR_ROUTER_LINK_COUNT                          9
-#define QDR_ROUTER_NODE_COUNT                          10
-#define QDR_ROUTER_AUTO_LINK_COUNT                     11
-#define QDR_ROUTER_CONNECTION_COUNT                    12
-#define QDR_ROUTER_PRESETTLED_DELIVERIES               13
-#define QDR_ROUTER_DROPPED_PRESETTLED_DELIVERIES       14
-#define QDR_ROUTER_ACCEPTED_DELIVERIES                 15
-#define QDR_ROUTER_REJECTED_DELIVERIES                 16
-#define QDR_ROUTER_RELEASED_DELIVERIES                 17
-#define QDR_ROUTER_MODIFIED_DELIVERIES                 18
-#define QDR_ROUTER_DELAYED_1SEC                        19
-#define QDR_ROUTER_DELAYED_10SEC                       20
-#define QDR_ROUTER_DELIVERIES_STUCK                    21
-#define QDR_ROUTER_DELIVERIES_INGRESS                  22
-#define QDR_ROUTER_DELIVERIES_EGRESS                   23
-#define QDR_ROUTER_DELIVERIES_TRANSIT                  24
-#define QDR_ROUTER_DELIVERIES_INGRESS_ROUTE_CONTAINER  25
-#define QDR_ROUTER_DELIVERIES_EGRESS_ROUTE_CONTAINER   26
-#define QDR_ROUTER_DELIVERIES_REDIRECTED               27
-#define QDR_ROUTER_LINKS_BLOCKED                       28
-#define QDR_ROUTER_UPTIME_SECONDS                      29
-#define QDR_ROUTER_MEMORY_USAGE                        30
-#define QDR_ROUTER_WORKER_THREADS                      31
-#define QDR_ROUTER_RSS_USAGE                           32
-#define QDR_ROUTER_CONNECTION_COUNTERS                 33
+#define QDR_ROUTER_VAN_ID                              6
+#define QDR_ROUTER_VERSION                             7
+#define QDR_ROUTER_METADATA                            8
+#define QDR_ROUTER_ADDR_COUNT                          9
+#define QDR_ROUTER_LINK_COUNT                          10
+#define QDR_ROUTER_NODE_COUNT                          11
+#define QDR_ROUTER_AUTO_LINK_COUNT                     12
+#define QDR_ROUTER_CONNECTION_COUNT                    13
+#define QDR_ROUTER_PRESETTLED_DELIVERIES               14
+#define QDR_ROUTER_DROPPED_PRESETTLED_DELIVERIES       15
+#define QDR_ROUTER_ACCEPTED_DELIVERIES                 16
+#define QDR_ROUTER_REJECTED_DELIVERIES                 17
+#define QDR_ROUTER_RELEASED_DELIVERIES                 18
+#define QDR_ROUTER_MODIFIED_DELIVERIES                 19
+#define QDR_ROUTER_DELAYED_1SEC                        20
+#define QDR_ROUTER_DELAYED_10SEC                       21
+#define QDR_ROUTER_DELIVERIES_STUCK                    22
+#define QDR_ROUTER_DELIVERIES_INGRESS                  23
+#define QDR_ROUTER_DELIVERIES_EGRESS                   24
+#define QDR_ROUTER_DELIVERIES_TRANSIT                  25
+#define QDR_ROUTER_DELIVERIES_INGRESS_ROUTE_CONTAINER  26
+#define QDR_ROUTER_DELIVERIES_EGRESS_ROUTE_CONTAINER   27
+#define QDR_ROUTER_DELIVERIES_REDIRECTED               28
+#define QDR_ROUTER_LINKS_BLOCKED                       29
+#define QDR_ROUTER_UPTIME_SECONDS                      30
+#define QDR_ROUTER_MEMORY_USAGE                        31
+#define QDR_ROUTER_WORKER_THREADS                      32
+#define QDR_ROUTER_RSS_USAGE                           33
+#define QDR_ROUTER_CONNECTION_COUNTERS                 34
 
 const char *qdr_router_columns[] =
     {"name",
@@ -67,6 +68,7 @@ const char *qdr_router_columns[] =
      "type",
      "mode",
      "area",
+     "vanId",
      "version",
      "metadata",
      "addrCount",
@@ -129,6 +131,13 @@ static void qdr_agent_write_column_CT(qd_composed_field_t *body, int col, qdr_co
     case QDR_ROUTER_AREA:
         if (core->router_area)
             qd_compose_insert_string(body, core->router_area);
+        else
+            qd_compose_insert_null(body);
+        break;
+
+    case QDR_ROUTER_VAN_ID:
+        if (core->van_id)
+            qd_compose_insert_string(body, core->van_id);
         else
             qd_compose_insert_null(body);
         break;

--- a/src/router_core/agent_router.h
+++ b/src/router_core/agent_router.h
@@ -21,7 +21,7 @@
 
 #include "router_core_private.h"
 
-#define QDR_ROUTER_COLUMN_COUNT  34
+#define QDR_ROUTER_COLUMN_COUNT  35
 
 extern const char *qdr_router_columns[QDR_ROUTER_COLUMN_COUNT + 1];
 

--- a/src/router_core/modules/address_lookup_client/address_lookup_client.c
+++ b/src/router_core/modules/address_lookup_client/address_lookup_client.c
@@ -39,21 +39,32 @@ typedef struct qcm_lookup_client_t {
  */
 static char *qdr_generate_temp_addr(qdr_core_t *core)
 {
-    static const char edge_template[] = "amqp:/_edge/%s/temp.%s";
-    static const char topo_template[] = "amqp:/_topo/%s/%s/temp.%s";
-    const size_t      max_template    = 19;  // printable chars
+    static const char *edge_template     = "amqp:/_edge/%s/temp.%s";
+    static const char *edge_template_van = "amqp:/_edge/%s/%s/temp.%s";
+    static const char *topo_template     = "amqp:/_topo/%s/%s/temp.%s";
+    static const char *topo_template_van = "amqp:/_topo/%s/%s/%s/temp.%s";
+    const size_t       max_template      = 20;  // printable chars
     char discriminator[QD_DISCRIMINATOR_SIZE];
 
     qd_generate_discriminator(discriminator);
-    size_t len = max_template + QD_DISCRIMINATOR_SIZE +
-        strlen(core->router_id) + strlen(core->router_area) + 1;
+    size_t len = max_template + QD_DISCRIMINATOR_SIZE + 1
+        + strlen(core->router_id) + strlen(core->router_area)
+        + (!!core->van_id ? strlen(core->van_id) : 0);
 
     int rc;
     char *buffer = qd_malloc(len);
     if (core->router_mode == QD_ROUTER_MODE_EDGE) {
-        rc = snprintf(buffer, len, edge_template, core->router_id, discriminator);
+        if (!!core->van_id) {
+            rc = snprintf(buffer, len, edge_template_van, core->router_id, core->van_id, discriminator);
+        } else {
+            rc = snprintf(buffer, len, edge_template, core->router_id, discriminator);
+        }
     } else {
-        rc = snprintf(buffer, len, topo_template, core->router_area, core->router_id, discriminator);
+        if (!!core->van_id) {
+            rc = snprintf(buffer, len, topo_template_van, core->router_area, core->router_id, core->van_id, discriminator);
+        } else {
+            rc = snprintf(buffer, len, topo_template, core->router_area, core->router_id, discriminator);
+        }
     }
     (void)rc; assert(rc < len);
     return buffer;

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -72,7 +72,7 @@ static void qdr_core_setup_init(qdr_core_t *core)
     qdr_adaptors_init(core);
 }
 
-qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area, const char *id)
+qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area, const char *id, const char *van_id)
 {
     qdr_core_t *core = NEW(qdr_core_t);
     ZERO(core);
@@ -81,6 +81,7 @@ qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area,
     core->router_mode         = mode;
     core->router_area         = area;
     core->router_id           = id;
+    core->van_id              = van_id;
     core->worker_thread_count = qd->thread_count;
     sys_atomic_init(&core->uptime_ticks, 0);
 
@@ -89,6 +90,10 @@ qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area,
     // module logs to the ROUTER_CORE module. There is no need to free the core->log as all log sources are.
     // freed by qd_dispatch_free()
     //
+    if (!!van_id) {
+        qd_log(LOG_ROUTER, QD_LOG_INFO, "Router is a member of Application Network: %s", van_id);
+    }
+
     //
     // Set up the threading support
     //
@@ -389,6 +394,11 @@ void qdr_router_node_free(qdr_core_t *core, qdr_node_t *rnode)
 int qdr_core_get_worker_thread_count(const qdr_core_t *core)
 {
     return core->worker_thread_count;
+}
+
+const char *qdr_core_van_id(const qdr_core_t *core)
+{
+    return core->van_id;
 }
 
 ALLOC_DECLARE(qdr_field_t);

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -854,6 +854,7 @@ struct qdr_core_t {
     qd_router_mode_t  router_mode;
     const char       *router_area;
     const char       *router_id;
+    const char       *van_id;
     int               worker_thread_count;
 
     qdr_address_config_list_t  addr_config;

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -1816,6 +1816,7 @@ qd_router_t *qd_router(qd_dispatch_t *qd, qd_router_mode_t mode, const char *are
     router->router_mode  = mode;
     router->router_area  = area;
     router->router_id    = id;
+    router->van_id       = qd->van_id;
     router->node         = qd_container_set_default_node_type(qd, &router_node, (void*) router, QD_DIST_BOTH);
 
     sys_mutex_init(&router->lock);
@@ -2328,7 +2329,7 @@ static void CORE_delivery_update(void *context, qdr_delivery_t *dlv, uint64_t di
 QD_EXPORT void qd_router_setup_late(qd_dispatch_t *qd)
 {
     qd->router->tracemask   = qd_tracemask();
-    qd->router->router_core = qdr_core(qd, qd->router->router_mode, qd->router->router_area, qd->router->router_id);
+    qd->router->router_core = qdr_core(qd, qd->router->router_mode, qd->router->router_area, qd->router->router_id, qd->router->van_id);
 
     amqp_direct_adaptor = qdr_protocol_adaptor(qd->router->router_core,
                                                "amqp",
@@ -2362,6 +2363,7 @@ void qd_router_free(qd_router_t *router)
     //
     router->router_id = 0;
     router->router_area = 0;
+    router->van_id = 0;
 
     qd_container_set_default_node_type(router->qd, 0, 0, QD_DIST_BOTH);
 

--- a/src/router_private.h
+++ b/src/router_private.h
@@ -57,6 +57,7 @@ struct qd_router_t {
     qd_router_mode_t          router_mode;
     const char               *router_area;
     const char               *router_id;
+    const char               *van_id;
     qd_node_t                *node;
 
     sys_mutex_t               lock;

--- a/tools/skstat.in
+++ b/tools/skstat.in
@@ -335,6 +335,8 @@ class BusManager:
         rows.append(('Version',        router.version))
         rows.append(('Mode',           router.mode))
         rows.append(('Router Id',      router.id))
+        if router.vanId is not None:
+            rows.append(('Van Id', router.vanId))
         try:
             rows.append(('Worker Threads', PlainNum(router.workerThreads)))
         except:


### PR DESCRIPTION
Added optional van_id to router configuration and management. Add van_id to temporary addresses when present.
Annotate adaptor addresses with the van-id.