### PR TITLE
Fixes #1432: prevent use-after-free race in cutthrough activation.

### DIFF
--- a/include/qpid/dispatch/cutthrough_utils.h
+++ b/include/qpid/dispatch/cutthrough_utils.h
@@ -24,10 +24,10 @@
 /**
  * Perform any needed cut-through notification upon the production or consumption of stream buffers
  * either inbound (from outside of the router) or outbound (to outside of the router).
- * 
- * @param msg - Pointer to a stream
+ *
+ * @param activation - activation record taken from the message (see message.c)
  */
-void cutthrough_notify_buffers_produced_inbound(qd_message_t *msg);
-void cutthrough_notify_buffers_consumed_outbound(qd_message_t *msg);
+void cutthrough_notify_buffers_produced_inbound(const qd_message_activation_t *activation);
+void cutthrough_notify_buffers_consumed_outbound(const qd_message_activation_t *activation);
 
 #endif

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -754,20 +754,6 @@ void qd_message_produce_buffers(qd_message_t *stream, qd_buffer_list_t *buffers)
 int qd_message_consume_buffers(qd_message_t *stream, qd_buffer_list_t *buffers, int limit);
 
 
-/**
- * Indicate whether this stream should be resumed from a stalled state.  This will be the case
- * if (a) the stream was stalled due to being full, and (b) the payload has shrunk down below
- * the resume threshold.
- *
- * If the result is true, there is a side effect of clearing the 'stalled' state.
- *
- * @param stream Pointer to the message
- * @return true Yes, the stream was stalled and buffer production may continue
- * @return false No, the stream was not stalled or it was stalled and is not yet ready to resume
- */
-bool qd_message_resume_from_stalled(qd_message_t *stream);
-
-
 typedef enum {
     QD_ACTIVATION_NONE = 0,
     QD_ACTIVATION_AMQP,
@@ -784,33 +770,31 @@ typedef struct {
  * Tell the message stream which connection is consuming its buffers.
  *
  * @param stream Pointer to the message
- * @param connection Pointer to the qd_connection that is consuming this stream's buffers
+ * @param activation Parameters for activating the consuming I/O thread
  */
 void qd_message_set_consumer_activation(qd_message_t *stream, qd_message_activation_t *activation);
 
 /**
- * Return the connection that is consuming this message stream's buffers.
+ * Cancel the activation. No further activations will be occur on return from this call.
  *
  * @param stream Pointer to the message
- * @return qd_connection_t* Pointer to the connection that is consuming buffers from this stream
  */
-void qd_message_get_consumer_activation(const qd_message_t *stream, qd_message_activation_t *activation);
+void qd_message_cancel_consumer_activation(qd_message_t *stream);
 
 /**
  * Tell the message stream which connection is producing its buffers.
  *
  * @param stream Pointer to the message
- * @param connection Pointer to the qd_connection that is consuming this stream's buffers
+ * @param activation Parameters for activating the producing I/O thread
  */
 void qd_message_set_producer_activation(qd_message_t *stream, qd_message_activation_t *activation);
 
 /**
- * Return the connection that is producing this message stream's buffers.
+ * Cancel the activation. No further activations will occur on return from this call.
  *
  * @param stream Pointer to the message
- * @return qd_connection_t* Pointer to the connection that is consuming buffers from this stream
  */
-void qd_message_get_producer_activation(const qd_message_t *stream, qd_message_activation_t *activation);
+void qd_message_cancel_producer_activation(qd_message_t *stream);
 
 ///@}
 

--- a/src/cutthrough_utils.c
+++ b/src/cutthrough_utils.c
@@ -25,7 +25,7 @@
 #include "adaptors/tcp_lite/tcp_lite.h"
 
 
-static void activate_connection(qd_message_activation_t *activation, qd_direction_t dir)
+static void activate_connection(const qd_message_activation_t *activation, qd_direction_t dir)
 {
     switch (activation->type) {
     case QD_ACTIVATION_NONE:
@@ -77,20 +77,13 @@ static void activate_connection(qd_message_activation_t *activation, qd_directio
 }
 
 
-void cutthrough_notify_buffers_produced_inbound(qd_message_t *msg)
+void cutthrough_notify_buffers_produced_inbound(const qd_message_activation_t *activation)
 {
-    qd_message_activation_t activation;
-    qd_message_get_consumer_activation(msg, &activation);
-    activate_connection(&activation, QD_OUTGOING);
+    activate_connection(activation, QD_OUTGOING);
 }
 
 
-void cutthrough_notify_buffers_consumed_outbound(qd_message_t *msg)
+void cutthrough_notify_buffers_consumed_outbound(const qd_message_activation_t *activation)
 {
-    bool unstall = qd_message_resume_from_stalled(msg);
-    if (unstall) {
-        qd_message_activation_t activation;
-        qd_message_get_producer_activation(msg, &activation);
-        activate_connection(&activation, QD_INCOMING);
-    }
+    activate_connection(activation, QD_INCOMING);
 }

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -156,7 +156,6 @@ typedef struct {
     qd_buffer_list_t         uct_slots[UCT_SLOT_COUNT];
     sys_atomic_t             uct_produce_slot;
     sys_atomic_t             uct_consume_slot;
-    sys_atomic_t             uct_producer_stalled;
     qd_message_activation_t  uct_producer_activation;
     qd_message_activation_t  uct_consumer_activation;
 } qd_message_content_t;

--- a/src/router_core/delivery.c
+++ b/src/router_core/delivery.c
@@ -160,6 +160,7 @@ void qdr_delivery_decref(qdr_core_t *core, qdr_delivery_t *delivery, const char 
         // The delivery deletion must occur inside the core thread.
         // Queue up an action to do the work.
         //
+        assert(!delivery->in_message_activation);  // you forgot to remove delivery from message activation!
         qdr_action_t *action = qdr_action(qdr_delete_delivery_CT, "delete_delivery");
         action->args.delivery.delivery = delivery;
         action->label = label;
@@ -679,8 +680,10 @@ void qdr_delivery_decref_CT(qdr_core_t *core, qdr_delivery_t *dlv, const char *l
     qd_log(LOG_ROUTER_CORE, QD_LOG_DEBUG, DLV_FMT " Delivery decref_CT: rc:%" PRIu32 " %s", DLV_ARGS(dlv),
            ref_count - 1, label);
 
-    if (ref_count == 1)
+    if (ref_count == 1) {
+        assert(!dlv->in_message_activation);  // you forgot to remove delivery from message activation!
         qdr_delete_delivery_internal_CT(core, dlv);
+    }
 }
 
 

--- a/tests/TCP_echo_client.py
+++ b/tests/TCP_echo_client.py
@@ -177,6 +177,8 @@ class TcpEchoClient:
                     self.logger.log('%s Failed to connect to host:%s port:%d - Retrying...'
                                     % (self.prefix, self.host, self.port))
 
+            laddr = self.sock.getsockname()
+            self.logger.log(f"{self.prefix} Connection from {laddr[0]}:{laddr[1]} to {self.host}:{self.port} active!")
             self.sock.setblocking(False)
 
             # set up selector


### PR DESCRIPTION
The patch adds locking to the cutthrough activation logic that prevents the activation handler from being released while another thread attempts using the activation.

Closes #1432