### PR TITLE
Fixes #1536: Replace unnecessary check for `n >= 0` with assertion that `n` is `unsigned long`

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -19,6 +19,8 @@
 
 #include "qpid/dispatch/amqp.h"
 
+#include "qpid/dispatch/static_assert.h"
+
 #include <errno.h>
 #include <netdb.h>
 #include <stdlib.h>
@@ -121,10 +123,11 @@ int qd_port_int(const char *port_str) {
     errno = 0;
     n = strtoul(port_str, &endptr, 10);
     if (*endptr == '\0') {
-        if (!errno && n >= 0 && n <= 0xFFFF)
+        STATIC_ASSERT(IS_SAME(unsigned long, n), n may not be negative);
+        if (!errno && n <= 0xFFFF) {
             return n;
-        else
-            return -1;
+        }
+        return -1;
     }
 
     // digits halfway?

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(unit_test_SOURCES
     hash_test.c
     thread_test.c
     platform_test.c
+    static_assert_test.c
     )
 
 add_executable(unit_tests ${unit_test_SOURCES})

--- a/tests/cpp/cpp_unit/CMakeLists.txt
+++ b/tests/cpp/cpp_unit/CMakeLists.txt
@@ -40,7 +40,6 @@ add_executable(cpp_unit
         test_amqp.cpp
         test_server.cpp
         test_terminus.cpp
-        test_static_assert.c
 )
 target_link_libraries(cpp_unit cpp-stub pthread skupper-router ${bfd_lib})
 # http_common.h includes "delivery.h"

--- a/tests/cpp/cpp_unit/CMakeLists.txt
+++ b/tests/cpp/cpp_unit/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(cpp_unit
         test_amqp.cpp
         test_server.cpp
         test_terminus.cpp
+        test_static_assert.c
 )
 target_link_libraries(cpp_unit cpp-stub pthread skupper-router ${bfd_lib})
 # http_common.h includes "delivery.h"

--- a/tests/cpp/cpp_unit/test_static_assert.c
+++ b/tests/cpp/cpp_unit/test_static_assert.c
@@ -1,6 +1,3 @@
-#ifndef STATIC_ASSERT_H
-#define STATIC_ASSERT_H
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,22 +17,14 @@
  * under the License.
  */
 
-#include <assert.h>
-#include <stdbool.h>
+#include "qpid/dispatch/static_assert.h"
 
-/** @file
- * STATIC_ASSERT allows you to do compile time assertions at file scope or in a function.
- * @param expr: a boolean expression that is valid at compile time.
- * @param msg: a "message" that must also be a valid identifier, i.e. message_with_underscores
- */
+static unsigned long ul;
+static long          l;
+static int           i;
 
+STATIC_ASSERT(IS_SAME(unsigned long, ul), ul is unsigned long);
+STATIC_ASSERT(!IS_SAME(unsigned long, l), l is not unsigned long);
 
-#define STATIC_ASSERT(expr, msg) static_assert(expr, #msg)
-
-#define STATIC_ASSERT_ARRAY_LEN(array, len) \
-    STATIC_ASSERT(sizeof(array)/sizeof(array[0]) == len, array##_wrong_size);
-
-// A C11 implementation of https://en.cppreference.com/w/cpp/types/is_same
-#define IS_SAME(type, var) _Generic(var, type: true, default: false)
-
-#endif // STATIC_ASSERT_H
+STATIC_ASSERT(!IS_SAME(int, l), l is not int);
+STATIC_ASSERT(!IS_SAME(long, i), i is not long);

--- a/tests/static_assert_test.c
+++ b/tests/static_assert_test.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "../include/qpid/dispatch/static_assert.h"
+#include "qpid/dispatch/static_assert.h"
 
 static unsigned long ul;
 static long          l;

--- a/tests/static_assert_test.c
+++ b/tests/static_assert_test.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "qpid/dispatch/static_assert.h"
+#include "../include/qpid/dispatch/static_assert.h"
 
 static unsigned long ul;
 static long          l;


### PR DESCRIPTION
Alternate fix to

* https://github.com/skupperproject/skupper-router/pull/1537

I saw that Coverity warning a long time ago already, but I always felt unsure about depending on a variable being of a certain type. Here's a solution that should pass Coverity and it still ensures that `n` is not negative.

Do with it as you will.

Fixes #1536