### PR TITLE
Fixes #1456 - Implemented the administrative ACCESS_POINT and LINK

### DIFF
--- a/include/qpid/dispatch/vanflow.h
+++ b/include/qpid/dispatch/vanflow.h
@@ -51,6 +51,7 @@ typedef enum vflow_record_type {
     VFLOW_RECORD_PROCESS_GROUP = 0x0c,  // A grouping of PROCESS
     VFLOW_RECORD_HOST          = 0x0d,  // Host (or Kubernetes Node) on which a process runs
     VFLOW_RECORD_LOG           = 0x0e,  // A notable router log event such as an error or warning
+    VFLOW_RECORD_ACCESS_POINT  = 0x0f,  // An access point for inter-router connections
 } vflow_record_type_t;
 
 // clang-format off
@@ -121,13 +122,17 @@ typedef enum vflow_attribute {
     VFLOW_ATTRIBUTE_LOG_TEXT         = 49,  // String
     VFLOW_ATTRIBUTE_SOURCE_FILE      = 50,  // String
     VFLOW_ATTRIBUTE_SOURCE_LINE      = 51,  // uint
+
+    VFLOW_ATTRIBUTE_LINK_COUNT       = 52,  // uint/counter
+    VFLOW_ATTRIBUTE_OPER_STATUS      = 53,  // String
+    VFLOW_ATTRIBUTE_ROLE             = 54,  // String
 } vflow_attribute_t;
 // clang-format on
 
 #define VALID_REF_ATTRS     0x00006000000000e6
-#define VALID_UINT_ATTRS    0x00099ffa07800119
-#define VALID_COUNTER_ATTRS 0x0000035000800000
-#define VALID_STRING_ATTRS  0x00060005787ffe00
+#define VALID_UINT_ATTRS    0x00199ffa07800119
+#define VALID_COUNTER_ATTRS 0x0010035000800000
+#define VALID_STRING_ATTRS  0x00660005787ffe00
 #define VALID_TRACE_ATTRS   0x0000000080000000
 
 typedef enum vflow_log_severity {

--- a/src/adaptors/amqp/amqp_adaptor.c
+++ b/src/adaptors/amqp/amqp_adaptor.c
@@ -20,6 +20,7 @@
 #include "private.h"
 #include "qd_connector.h"
 #include "qd_connection.h"
+#include "qd_listener.h"
 #include "container.h"
 #include "node_type.h"
 
@@ -2366,8 +2367,12 @@ static void qd_amqp_adaptor_final(void *adaptor_context)
         if (ctx->policy_settings)
             qd_policy_settings_free(ctx->policy_settings);
         if (ctx->connector) {
-            ctx->connector->qd_conn = 0;
-            qd_connector_decref(ctx->connector);
+            qd_connector_remove_connection(ctx->connector);
+            ctx->connector = 0;
+        }
+        if (ctx->listener) {
+            qd_listener_remove_connection(ctx->listener, ctx);
+            ctx->listener = 0;
         }
         sys_atomic_destroy(&ctx->wake_core);
         sys_atomic_destroy(&ctx->wake_cutthrough_inbound);

--- a/src/adaptors/amqp/connection_manager.c
+++ b/src/adaptors/amqp/connection_manager.c
@@ -30,6 +30,7 @@
 #include "qpid/dispatch/ctools.h"
 #include "qpid/dispatch/failoverlist.h"
 #include "qpid/dispatch/threading.h"
+#include "qpid/dispatch/vanflow.h"
 
 #include <proton/listener.h>
 
@@ -147,7 +148,7 @@ static void log_config(qd_server_config_t *c, const char *what, bool create)
 QD_EXPORT qd_listener_t *qd_dispatch_configure_listener(qd_dispatch_t *qd, qd_entity_t *entity)
 {
     qd_connection_manager_t *cm = qd->connection_manager;
-    qd_listener_t *li = qd_server_listener(qd->server);
+    qd_listener_t *li = qd_listener(qd->server);
     if (!li || qd_server_config_load(qd, &li->config, entity, true, 0) != QD_ERROR_NONE) {
         qd_log(LOG_CONN_MGR, QD_LOG_ERROR, "Unable to create listener: %s", qd_error_message());
         qd_listener_decref(li);
@@ -166,6 +167,19 @@ QD_EXPORT qd_listener_t *qd_dispatch_configure_listener(qd_dispatch_t *qd, qd_en
     } else {
         li->config.failover_list = 0;
     }
+
+    //
+    // Set up the vanflow record for this listener (ACCESS_POINT).
+    // Do this only for router-to-routers links: not mgmt/metrics/healthz/websockets listeners
+    //
+    if (strcmp(li->config.role, "inter-router") == 0 ||
+        strcmp(li->config.role, "edge") == 0 ||
+        strcmp(li->config.role, "inter-edge") == 0) {
+        li->vflow_record = vflow_start_record(VFLOW_RECORD_ACCESS_POINT, 0);
+        vflow_set_string(li->vflow_record, VFLOW_ATTRIBUTE_ROLE, li->config.role);
+        vflow_set_uint64(li->vflow_record, VFLOW_ATTRIBUTE_LINK_COUNT, 0);
+    }
+
     DEQ_ITEM_INIT(li);
     DEQ_INSERT_TAIL(cm->listeners, li);
     log_config(&li->config, "Listener", true);
@@ -414,8 +428,17 @@ QD_EXPORT qd_connector_t *qd_dispatch_configure_connector(qd_dispatch_t *qd, qd_
         item->host_port = malloc(hplen);
         snprintf(item->host_port, hplen, "%s:%s", item->host , item->port);
 
-        DEQ_INSERT_TAIL(ct->conn_info_list, item);
+        //
+        // Set up the vanflow record for this connector (LINK)
+        //
+        ct->vflow_record = vflow_start_record(VFLOW_RECORD_LINK, 0);
+        vflow_set_string(ct->vflow_record, VFLOW_ATTRIBUTE_ROLE, ct->config.role);
+        vflow_set_string(ct->vflow_record, VFLOW_ATTRIBUTE_OPER_STATUS, "down");
+        vflow_set_string(ct->vflow_record, VFLOW_ATTRIBUTE_PROTOCOL, item->scheme);
+        vflow_set_string(ct->vflow_record, VFLOW_ATTRIBUTE_DESTINATION_HOST, item->host);
+        vflow_set_string(ct->vflow_record, VFLOW_ATTRIBUTE_DESTINATION_PORT, item->port);
 
+        DEQ_INSERT_TAIL(ct->conn_info_list, item);
         return ct;
     }
 

--- a/src/adaptors/amqp/qd_connection.h
+++ b/src/adaptors/amqp/qd_connection.h
@@ -115,8 +115,9 @@ struct qd_connection_t {
 
 ALLOC_DECLARE_SAFE(qd_connection_t);
 
-qd_connection_t *qd_server_connection(qd_server_t *server, qd_server_config_t* config);
-qd_connection_t *qd_server_connection_impl(qd_server_t *server, qd_server_config_t *config, qd_connection_t *ctx, qd_connector_t *connector);
+// initialize a newly allocated qd_connection_t
+void qd_connection_init(qd_connection_t *qd_conn, qd_server_t *server, qd_server_config_t *config,
+                        qd_connector_t *connector, qd_listener_t *listener);
 
 qd_connector_t* qd_connection_connector(const qd_connection_t *c);
 

--- a/src/adaptors/amqp/qd_connector.h
+++ b/src/adaptors/amqp/qd_connector.h
@@ -32,6 +32,7 @@
 typedef struct qd_timer_t  qd_timer_t;
 typedef struct qd_server_t qd_server_t;
 typedef struct qd_connection_t qd_connection_t;
+typedef struct vflow_record_t  vflow_record_t;
 
 typedef enum {
     CXTR_STATE_INIT = 0,
@@ -58,6 +59,7 @@ typedef struct qd_connector_t {
     sys_mutex_t               lock;
     cxtr_state_t              state;
     qd_connection_t          *qd_conn;
+    vflow_record_t           *vflow_record;
 
     /* This conn_list contains all the connection information needed to make a connection. It also includes failover connection information */
     qd_failover_item_list_t   conn_info_list;
@@ -94,5 +96,12 @@ bool qd_connector_has_failover_info(const qd_connector_t* ct);
 const char *qd_connector_policy_vhost(const qd_connector_t* ct);
 void qd_connector_handle_transport_error(qd_connector_t *connector, uint64_t connection_id, pn_condition_t *condition);
 void qd_connector_remote_opened(qd_connector_t *connector);
-void qd_connector_release_connection(qd_connector_t *connector, qd_connection_t *qd_conn);
+
+// add a new connection to the parent connector
+void qd_connector_add_connection(qd_connector_t *connector, qd_connection_t *ctx);
+
+// remove the child connection
+// NOTE WELL: this may free the connector if the connection is holding the last
+// reference to it
+void qd_connector_remove_connection(qd_connector_t *connector);
 #endif

--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -1022,13 +1022,13 @@ static int callback_amqpws(struct lws *wsi, enum lws_callback_reasons reason,
         if (hl == NULL || !hl->listener->config.websockets) {
             return unexpected_close(c->wsi, "cannot-upgrade");
         }
-        c->qd_conn = qd_server_connection(hs->server, &hl->listener->config);
-        if (c->qd_conn == NULL) {
-            return unexpected_close(c->wsi, "out-of-memory");
-        }
+
+        c->qd_conn = new_qd_connection_t();
+        ZERO(c->qd_conn);
+        qd_connection_init(c->qd_conn, hs->server, &hl->listener->config, 0, hl->listener);
         c->qd_conn->context = c;
         c->qd_conn->wake = connection_wake;
-        c->qd_conn->listener = hl->listener;
+
         lws_get_peer_simple(wsi, c->qd_conn->rhost, sizeof(c->qd_conn->rhost));
         int err = pn_connection_driver_init(&c->driver, c->qd_conn->pn_conn, NULL);
         if (err) {

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -356,7 +356,6 @@ void qdr_core_free(qdr_core_t *core)
     if (core->data_links_by_mask_bit)      free(core->data_links_by_mask_bit);
     if (core->neighbor_free_mask)          qd_bitmask_free(core->neighbor_free_mask);
     if (core->rnode_conns_by_mask_bit)     free(core->rnode_conns_by_mask_bit);
-    if (core->vflow_links_by_mask_bit)     free(core->vflow_links_by_mask_bit);
     if (core->group_correlator_by_maskbit) {
         for (int idx = 0; idx < qd_bitmask_width(); idx++) {
             free(core->group_correlator_by_maskbit[idx]);

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -878,7 +878,6 @@ struct qdr_core_t {
     qdr_node_t            **routers_by_mask_bit;          ///< indexed by qdr_node_t->mask_bit
     qdr_connection_t      **rnode_conns_by_mask_bit;      ///< inter-router conns indexed by conn->mask_bit
     qdr_link_t            **control_links_by_mask_bit;    ///< indexed by qdr_node_t->link_mask_bit, qdr_connection_t->mask_bit
-    vflow_record_t        **vflow_links_by_mask_bit;      ///< indexed by qdr_node_t->mask_bit
     qdr_priority_sheaf_t   *data_links_by_mask_bit;       ///< indexed by qdr_node_t->link_mask_bit, qdr_connection_t->mask_bit
     qdr_connection_list_t   unallocated_group_members;    ///< List of unallocated group members (i.e. before the group is given a maskbit)
     char                  **group_correlator_by_maskbit;  ///< Group correlator number indexed by conn->maskbit

--- a/src/vanflow.c
+++ b/src/vanflow.c
@@ -685,6 +685,7 @@ static const char *_vflow_record_type_name(const vflow_record_t *record)
     case VFLOW_RECORD_PROCESS_GROUP : return "PROCESS_GROUP";
     case VFLOW_RECORD_HOST          : return "HOST";
     case VFLOW_RECORD_LOG           : return "LOG";
+    case VFLOW_RECORD_ACCESS_POINT  : return "ACCESS_POINT";
     }
     return "UNKNOWN";
 }
@@ -745,6 +746,9 @@ static const char *_vflow_attribute_name(const vflow_attribute_data_t *data)
     case VFLOW_ATTRIBUTE_LOG_TEXT         : return "logText";
     case VFLOW_ATTRIBUTE_SOURCE_FILE      : return "sourceFile";
     case VFLOW_ATTRIBUTE_SOURCE_LINE      : return "sourceLine";
+    case VFLOW_ATTRIBUTE_LINK_COUNT       : return "linkCount";
+    case VFLOW_ATTRIBUTE_OPER_STATUS      : return "operStatus";
+    case VFLOW_ATTRIBUTE_ROLE             : return "role";
     }
     return "UNKNOWN";
 }

--- a/tests/cpp/cpp_system/test_listener_startup.cpp
+++ b/tests/cpp/cpp_system/test_listener_startup.cpp
@@ -44,7 +44,7 @@ void check_amqp_listener_startup_log_message(qd_server_config_t config, std::str
     CaptureCStream css(stderr);
     qdr.initialize("./minimal_trace.conf");
 
-    qd_listener_t *li = qd_server_listener(qdr.qd->server);
+    qd_listener_t *li = qd_listener(qdr.qd->server);
     li->config = config;
 
     CHECK(qd_listener_listen(li));
@@ -71,7 +71,7 @@ void check_http_listener_startup_log_message(qd_server_config_t config, std::str
     CaptureCStream css(stderr);
     qdr.initialize("./minimal_trace.conf");
 
-    qd_listener_t *li = qd_server_listener(qdr.qd->server);
+    qd_listener_t *li = qd_listener(qdr.qd->server);
     li->config = config;
 
     const bool http_supported = qd_server_http(qdr.qd->server) != nullptr;


### PR DESCRIPTION
This also separates the closure-of-all-connections from the freeing of the server module so that connections can be closed at an earlier point of the shutdown sequence.

This also adds accepted-connections to the listener reference counts for a more orderly freeing of resources.

Original work by Ted Ross. Ported to amqp adaptor and obfuscated by kgiusti