### PR TITLE
Issue #1573: disable test for temporary workaround

### DIFF
--- a/tests/system_tests_two_routers.py
+++ b/tests/system_tests_two_routers.py
@@ -1735,6 +1735,7 @@ class TwoRouterExtensionStateTest(TestCase):
         Verify that disposition state set by the publisher is available to all
         consumers
         """
+        self.skipTest("Temporarily disabled, see Issue #1573")
         rxs = [MyExtendedReceiver(self.RouterA.addresses[0],
                                   "multicast/thingy")
                for x in range(3)]


### PR DESCRIPTION
Skip test_03_multicast for now until we determine cause of the failure.