### PR TITLE
TCPEchoServer: abort the transport on connection lost 

### DIFF
--- a/tests/TCP_echo_server.py
+++ b/tests/TCP_echo_server.py
@@ -86,6 +86,7 @@ class TcpEchoServerHandler(asyncio.Protocol):
 
     def connection_lost(self, exc):
         self.logger.log(f' {self.name}: Connection to {self.peername} lost, exception={exc}')
+        self.transport.abort()
 
     def eof_received(self):
         self.logger.log(f' {self.name}: EOF received from peer {self.peername}')


### PR DESCRIPTION
This is to avoid potential ReseourceWarnings and write() exceptions during tearDown() of SSL tests. I hit this with system_tests_tcp_conns_terminate.py but I think it can happen in any other test which uses the echo client with SSL. Example warning :
```

2024-07-26 15:48:08.192808  TerminateTcpConnectionsTest ECHO_SERVER_address_default_ssl: Connection to 127.0.0.1:49886 lost, exception=None
/usr/lib/python3.10/asyncio/sslproto.py:320: ResourceWarning: unclosed transport <asyncio.sslproto._SSLProtocolTransport object at 0xffffb8eef460>
  _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
 ```