### PR TITLE
Fixes #1594 - Add link-cost to link records in vanflow.

### DIFF
--- a/src/adaptors/amqp/connection_manager.c
+++ b/src/adaptors/amqp/connection_manager.c
@@ -440,6 +440,7 @@ QD_EXPORT qd_connector_t *qd_dispatch_configure_connector(qd_dispatch_t *qd, qd_
             ct->vflow_record = vflow_start_record(VFLOW_RECORD_LINK, 0);
             vflow_set_string(ct->vflow_record, VFLOW_ATTRIBUTE_NAME, ct->config.name);
             vflow_set_string(ct->vflow_record, VFLOW_ATTRIBUTE_ROLE, ct->config.role);
+            vflow_set_uint64(ct->vflow_record, VFLOW_ATTRIBUTE_LINK_COST, ct->config.inter_router_cost);
             vflow_set_string(ct->vflow_record, VFLOW_ATTRIBUTE_OPER_STATUS, "down");
             vflow_set_uint64(ct->vflow_record, VFLOW_ATTRIBUTE_DOWN_COUNT, 0);
             vflow_set_string(ct->vflow_record, VFLOW_ATTRIBUTE_PROTOCOL, item->scheme);

--- a/tests/system_tests_vflow.py
+++ b/tests/system_tests_vflow.py
@@ -360,7 +360,7 @@ class VFlowInterRouterTest(TestCase):
                             'dataConnectionCount': 4}),
                 ('listener', {'role': 'normal',
                               'port': cls.tester.get_port()}),
-                ('connector', {'role': 'inter-router',
+                ('connector', {'role': 'inter-router', 'cost': 23,
                                'port': cls.inter_router_port}),
                 ('tcpConnector', {'host': '127.0.0.1',
                                   'port': cls.tcp_connector_port,
@@ -471,6 +471,7 @@ class VFlowInterRouterTest(TestCase):
                                'REASON': ANY_VALUE}),
                      ('LINK', {'OPER_STATUS': 'up',
                                'ROLE': 'inter-router',
+                               'LINK_COST': 23,
                                'DESTINATION_PORT': str(self.inter_router_port)})
                      ],
             "INTB": [('ROUTER_ACCESS', {'LINK_COUNT': 1,


### PR DESCRIPTION
Added the missing cost attribute to link records.