### PR TITLE
Fixes #1625: schedule output on core links after flow update

### DIFF
--- a/src/router_core/modules/edge_addr_tracking/edge_addr_tracking.c
+++ b/src/router_core/modules/edge_addr_tracking/edge_addr_tracking.c
@@ -227,7 +227,7 @@ static void qdrc_send_message(qdr_core_t *core, qdr_address_t *addr, qdrc_endpoi
     qd_message_t *msg = qdcm_edge_create_address_dlv(core, addr, insert_addr);
     qdr_delivery_t *dlv = qdrc_endpoint_delivery_CT(core, endpoint, msg);
 
-    qdrc_endpoint_send_CT(core, endpoint, dlv, true);
+    qdrc_endpoint_send_CT(core, endpoint, dlv, false);
 }
 
 

--- a/src/router_core/modules/mesh_discovery/mesh_discovery_edge.c
+++ b/src/router_core/modules/mesh_discovery/mesh_discovery_edge.c
@@ -95,7 +95,7 @@ static void send_mesh_id_to_interior(void)
         qd_compose_free(content);
         
         qdr_delivery_t *delivery = qdrc_endpoint_delivery_CT(state.core, state.interior_sender, msg);
-        qdrc_endpoint_send_CT(state.core, state.interior_sender, delivery, true);
+        qdrc_endpoint_send_CT(state.core, state.interior_sender, delivery, false);
 
         state.interior_sender_credit--;
         state.interior_needs_update = false;
@@ -127,7 +127,7 @@ static void send_bid(mesh_peer_t *peer)
     qd_compose_free(content);
     
     qdr_delivery_t *delivery = qdrc_endpoint_delivery_CT(state.core, peer->sender, msg);
-    qdrc_endpoint_send_CT(state.core, peer->sender, delivery, true);
+    qdrc_endpoint_send_CT(state.core, peer->sender, delivery, false);
 
     peer->send_credit--;
     peer->needs_update = false;


### PR DESCRIPTION
Ensure core links are included in link credit processing. Remove dead code and extra attempt to queue link to the work list.