### PR TITLE
CI: add call to stop async tool when expecting failure

### DIFF
--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -1151,10 +1151,11 @@ class RouterTestSslProfileUpdateClients(RouterTestSslBase):
                      'allowed_mechs': "EXTERNAL",
                      'ssl_domain': ssl_domain}
         with self.assertRaises(AsyncTestReceiver.TestReceiverException) as exc:
-            AsyncTestReceiver(f"amqps://localhost:{self.listener1_port}",
-                              source="test/addr",
-                              container_id="FooRx2",
-                              conn_args=conn_args)
+            atr = AsyncTestReceiver(f"amqps://localhost:{self.listener1_port}",
+                                    source="test/addr",
+                                    container_id="FooRx2",
+                                    conn_args=conn_args)
+            atr.stop()
         self.assertIn("certificate verify failed", str(exc.exception), f"{exc.exception}")
 
         ssl_domain = SSLDomain(SSLDomain.MODE_CLIENT)
@@ -1165,10 +1166,11 @@ class RouterTestSslProfileUpdateClients(RouterTestSslBase):
                      'allowed_mechs': "EXTERNAL",
                      'ssl_domain': ssl_domain}
         with self.assertRaises(AsyncTestReceiver.TestReceiverException) as exc:
-            AsyncTestReceiver(f"amqps://localhost:{self.listener2_port}",
-                              source="test/addr",
-                              container_id="FooRx3",
-                              conn_args=conn_args)
+            atr = AsyncTestReceiver(f"amqps://localhost:{self.listener2_port}",
+                                    source="test/addr",
+                                    container_id="FooRx3",
+                                    conn_args=conn_args)
+            atr.stop()
         self.assertIn("certificate verify failed", str(exc.exception), f"{exc.exception}")
 
         #


### PR DESCRIPTION
It seems that the AsyncTestSender does not always raise exception when the TLS handshake fails.  Add a call to stop() to force flush any detected exceptions. This is the same behavior as other tests.