### PR TITLE
Fixes #1664: Additional fix. Removed VFLOW_ATTRIBUTE_OCTET_RATE as it…

### DIFF
--- a/src/observers/http2/http2_observer.c
+++ b/src/observers/http2/http2_observer.c
@@ -132,7 +132,6 @@ int on_begin_header_callback(qd_http2_decoder_connection_t *conn_state,
             stream_info->vflow = vflow_start_record(VFLOW_RECORD_BIFLOW_APP, transport_handle->vflow);
             vflow_set_string(stream_info->vflow, VFLOW_ATTRIBUTE_PROTOCOL, "HTTP/2");
             vflow_set_uint64(stream_info->vflow, VFLOW_ATTRIBUTE_OCTETS, 0);
-            vflow_add_rate(stream_info->vflow, VFLOW_ATTRIBUTE_OCTETS, VFLOW_ATTRIBUTE_OCTET_RATE);
             stream_info->stream_id = stream_id;
             vflow_set_uint64(stream_info->vflow, VFLOW_ATTRIBUTE_STREAM_ID, stream_info->stream_id);
             vflow_latency_start(stream_info->vflow);


### PR DESCRIPTION
… is already being calculated by the tcp adaptor