### PR TITLE
Fixes #1675: Remove unused link-route code

### DIFF
--- a/include/qpid/dispatch/protocol_adaptor.h
+++ b/include/qpid/dispatch/protocol_adaptor.h
@@ -720,14 +720,15 @@ const char *qdr_link_internal_address(const qdr_link_t *link);
 bool qdr_link_is_anonymous(const qdr_link_t *link);
 
 /**
- * qdr_link_is_routed
+ * qdr_link_is_core_endpoint
  *
- * Indicate whether the link is link-routed.
+ * Indicate whether the link is terminated in the router core. These links are used by the core to send and receive
+ * messages.
  *
  * @param link Link object
- * @return True if the link is link-routed.
+ * @return True if the link is terminated in the core
  */
-bool qdr_link_is_routed(const qdr_link_t *link);
+bool qdr_link_is_core_endpoint(const qdr_link_t *link);
 
 /**
  * qdr_link_strip_annotations_in
@@ -851,10 +852,9 @@ qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
                                     bool settled, qd_bitmask_t *link_exclusion, int ingress_index,
                                     uint64_t remote_disposition,
                                     qd_delivery_state_t *remote_state);
-qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *msg, bool settled,
-                                                const uint8_t *tag, int tag_length,
-                                                uint64_t remote_disposition,
-                                                qd_delivery_state_t *remote_state);
+qdr_delivery_t *qdr_link_deliver_to_core(qdr_link_t *link, qd_message_t *msg, bool settled,
+                                         uint64_t remote_disposition,
+                                         qd_delivery_state_t *remote_state);
 
 /**
  * qdr_link_process_deliveries

--- a/python/skupper_router/management/skrouter.json
+++ b/python/skupper_router/management/skrouter.json
@@ -1422,10 +1422,6 @@
                     "type": "integer",
                     "description": "The capacity, in deliveries, for the link.  The number of undelivered plus unsettled deliveries shall not exceed the capacity.  This is enforced by link flow control."
                 },
-                "peer": {
-                    "type": "string",
-                    "description": "Identifier of the paired link if this is an attach-routed link."
-                },
                 "undeliveredCount": {
                     "type": "integer",
                     "graph": true,

--- a/src/adaptors/amqp/amqp_adaptor.c
+++ b/src/adaptors/amqp/amqp_adaptor.c
@@ -770,7 +770,10 @@ static bool AMQP_rx_handler(qd_router_t *router, qd_link_t *link)
         break;
     }
 
-    // Handle deliveries destined to a core endpoint.
+    // Intercept deliveries destined to a core endpoint and hand them directly to the router core. Incoming links to a
+    // core endpoint address are "attach routed". This means the incoming link is bound directly to the core endpoint
+    // consumer when the first attach arrives. Afterwards deliveries arriving on this link are passed directly to the
+    // core endpoint rather than going through the delivery forwarding logic.
     //
     if (qdr_link_is_core_endpoint(rlink)) {
         log_link_message(conn, pn_link, msg);

--- a/src/router_core/agent_link.c
+++ b/src/router_core/agent_link.c
@@ -30,28 +30,27 @@
 #define QDR_LINK_LINK_DIR                 5
 #define QDR_LINK_OWNING_ADDR              6
 #define QDR_LINK_CAPACITY                 7
-#define QDR_LINK_PEER                     8
-#define QDR_LINK_UNDELIVERED_COUNT        9
-#define QDR_LINK_UNSETTLED_COUNT          10
-#define QDR_LINK_DELIVERY_COUNT           11
-#define QDR_LINK_CONNECTION_ID            12
-#define QDR_LINK_ADMIN_STATE              13
-#define QDR_LINK_OPER_STATE               14
-#define QDR_LINK_PRESETTLED_COUNT         15
-#define QDR_LINK_DROPPED_PRESETTLED_COUNT 16
-#define QDR_LINK_ACCEPTED_COUNT           17
-#define QDR_LINK_REJECTED_COUNT           18
-#define QDR_LINK_RELEASED_COUNT           19
-#define QDR_LINK_MODIFIED_COUNT           20
-#define QDR_LINK_DELAYED_1SEC             21
-#define QDR_LINK_DELAYED_10SEC            22
-#define QDR_LINK_DELIVERIES_STUCK         23
-#define QDR_LINK_OPEN_MOVED_STREAMS       24
-#define QDR_LINK_INGRESS_HISTOGRAM        25
-#define QDR_LINK_PRIORITY                 26
-#define QDR_LINK_SETTLE_RATE              27
-#define QDR_LINK_CREDIT_AVAILABLE         28
-#define QDR_LINK_ZERO_CREDIT_SECONDS      29
+#define QDR_LINK_UNDELIVERED_COUNT        8
+#define QDR_LINK_UNSETTLED_COUNT          9
+#define QDR_LINK_DELIVERY_COUNT           10
+#define QDR_LINK_CONNECTION_ID            11
+#define QDR_LINK_ADMIN_STATE              12
+#define QDR_LINK_OPER_STATE               13
+#define QDR_LINK_PRESETTLED_COUNT         14
+#define QDR_LINK_DROPPED_PRESETTLED_COUNT 15
+#define QDR_LINK_ACCEPTED_COUNT           16
+#define QDR_LINK_REJECTED_COUNT           17
+#define QDR_LINK_RELEASED_COUNT           18
+#define QDR_LINK_MODIFIED_COUNT           19
+#define QDR_LINK_DELAYED_1SEC             20
+#define QDR_LINK_DELAYED_10SEC            21
+#define QDR_LINK_DELIVERIES_STUCK         22
+#define QDR_LINK_OPEN_MOVED_STREAMS       23
+#define QDR_LINK_INGRESS_HISTOGRAM        24
+#define QDR_LINK_PRIORITY                 25
+#define QDR_LINK_SETTLE_RATE              26
+#define QDR_LINK_CREDIT_AVAILABLE         27
+#define QDR_LINK_ZERO_CREDIT_SECONDS      28
 
 const char *qdr_link_columns[] =
     {"name",
@@ -62,7 +61,6 @@ const char *qdr_link_columns[] =
      "linkDir",
      "owningAddr",
      "capacity",
-     "peer",
      "undeliveredCount",
      "unsettledCount",
      "deliveryCount",
@@ -155,10 +153,6 @@ static void qdr_agent_write_column_CT(qdr_core_t *core, qd_composed_field_t *bod
 
     case QDR_LINK_CAPACITY:
         qd_compose_insert_uint(body, link->capacity);
-        break;
-
-    case QDR_LINK_PEER:  // link-routing no longer supported
-        qd_compose_insert_null(body);
         break;
 
     case QDR_LINK_UNDELIVERED_COUNT:

--- a/src/router_core/agent_link.c
+++ b/src/router_core/agent_link.c
@@ -147,8 +147,6 @@ static void qdr_agent_write_column_CT(qdr_core_t *core, qd_composed_field_t *bod
     case QDR_LINK_OWNING_ADDR:
         if(link->owning_addr)
             qd_compose_insert_string(body, address_key(link->owning_addr));
-        else if (link->connected_link && link->connected_link->terminus_addr)
-            qd_compose_insert_string(body, link->connected_link->terminus_addr);
         else if (link->terminus_addr)
             qd_compose_insert_string(body, link->terminus_addr);
         else
@@ -159,13 +157,8 @@ static void qdr_agent_write_column_CT(qdr_core_t *core, qd_composed_field_t *bod
         qd_compose_insert_uint(body, link->capacity);
         break;
 
-    case QDR_LINK_PEER:
-        if (link->connected_link) {
-            char id[100];
-            snprintf(id, 100, "%"PRId64, link->connected_link->identity);
-            qd_compose_insert_string(body, id);
-        } else
-            qd_compose_insert_null(body);
+    case QDR_LINK_PEER:  // link-routing no longer supported
+        qd_compose_insert_null(body);
         break;
 
     case QDR_LINK_UNDELIVERED_COUNT:

--- a/src/router_core/agent_link.h
+++ b/src/router_core/agent_link.h
@@ -29,7 +29,7 @@ void qdra_link_update_CT(qdr_core_t          *core,
                          qdr_query_t         *query,
                          qd_parsed_field_t   *in_body);
 
-#define QDR_LINK_COLUMN_COUNT  30
+#define QDR_LINK_COLUMN_COUNT  29
 
 extern const char *qdr_link_columns[QDR_LINK_COLUMN_COUNT + 1];
 

--- a/src/router_core/delivery.c
+++ b/src/router_core/delivery.c
@@ -346,12 +346,11 @@ bool qdr_delivery_settled_CT(qdr_core_t *core, qdr_delivery_t *dlv) TA_NO_THREAD
     }
 
     //
-    // If this is an incoming link and it is not link-routed or inter-router, issue
-    // one replacement credit on the link.  Note that credit on inter-router links is
-    // issued immediately even for unsettled deliveries.
+    // If this is an incoming link and it is not inter-router or inter-edge, issue one replacement credit on the link.
+    // Note that credit on inter-router links is issued immediately even for unsettled deliveries.
     //
     if (moved && link->link_direction == QD_INCOMING &&
-        link->link_type != QD_LINK_ROUTER && !link->edge && !link->connected_link)
+        link->link_type != QD_LINK_ROUTER && !link->edge)
         qdr_link_issue_credit_CT(core, link, 1, false);
 
     return moved;

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -318,20 +318,6 @@ void qdr_forward_deliver_CT(qdr_core_t *core, qdr_link_t *out_link, qdr_delivery
     sys_mutex_unlock(&out_link->conn->work_lock);
 
     //
-    // We are dealing here only with link routed deliveries
-    // If the out_link has a connected link and if the out_link is an inter-router link, increment the global deliveries_transit
-    // If the out_link is a route container link, add to the global deliveries_egress
-    //
-    if (out_link->connected_link) {
-        if (out_link->conn->role == QDR_ROLE_INTER_ROUTER) {
-            core->deliveries_transit++;
-        }
-        else {
-            core->deliveries_egress++;
-        }
-    }
-
-    //
     // Activate the outgoing connection for later processing.
     //
     qdr_connection_activate_CT(core, out_link->conn);

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -140,8 +140,6 @@ struct qdr_action_t {
             qdr_delivery_t      *delivery;
             qd_delivery_state_t *dstate;
             uint64_t             disposition;
-            uint8_t              tag[32];
-            int                  tag_length;
             bool                 settled;
             bool                 presettled;  // true if remote settles while msg is in flight
             bool                 more;  // true if there are more frames arriving, false otherwise
@@ -450,7 +448,6 @@ struct qdr_link_t {
     int                      detach_count;       ///< 0, 1, or 2 depending on the state of the lifecycle
     uint32_t                 open_moved_streams; ///< Number of still-open streaming deliveries that were moved from this link
     qdr_address_t           *owning_addr;        ///< [ref] Address record that owns this link
-    qdr_link_t              *connected_link;     ///< [ref] If this is a link-route, reference the connected link
     qdrc_endpoint_t         *core_endpoint;      ///< [ref] Set if this link terminates on an in-core endpoint
     qdr_link_ref_t          *ref[QDR_LINK_LIST_CLASSES];  ///< Pointers to containing reference objects
     qdr_auto_link_t         *auto_link;          ///< [ref] Auto_link that owns this link


### PR DESCRIPTION
This patch retains the parts of the link routing code that was leveraged by the core link endpoint feature. This retained code has been renamed to identify its use by core endpoints.