### PR TITLE
Fixes #1698: prevent use-after-free of qd_link_t on session close

### DIFF
--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -1093,6 +1093,14 @@ class OneRouterTest(TestCase):
         test.run()
         self.assertIsNone(test.error)
 
+    def test_52_amqp_session_flap_test(self):
+        """
+        Test creating and tearing down active sessions
+        """
+        test = AMQPSessionFlapTest(self.address)
+        test.run()
+        self.assertIsNone(test.error)
+
 
 class Entity:
     def __init__(self, status_code, status_description, attrs):
@@ -3357,6 +3365,95 @@ class LinkReattachTest(MessagingHandler):
         if "reattach not supported" not in desc:
             self.error = f"Unexpected error: {desc}"
         self.done()
+
+    def run(self):
+        Container(self).run()
+
+
+class AMQPSessionFlapTest(MessagingHandler):
+    """
+    This test stresses the creation and deletion of AMQP Sessions.
+    It repeatedly creates sessions then tears them down while links are
+    actively sending messages
+    """
+    def __init__(self, router_address):
+        super(AMQPSessionFlapTest, self).__init__()
+        self.router_address = router_address
+        self.target = "session/flap/test"
+        self.error = None
+        self.rx_conn = None
+        self.receiver = None
+        self.tx_conn = None
+        self.tx_session = None
+
+        # repeat using a new session tx_session_limit iterations
+        self.tx_session_limit = 10
+        self.tx_session_count = 0
+
+        # repeat using a new link tx_link_limit iterations
+        self.tx_link_limit = 100
+        self.tx_links = []
+
+        # count number of messages in flight
+        self.tx_messages = 0
+        self.timer = None
+
+    def done(self, error=None):
+        self.error = error
+        if self.timer:
+            self.timer.cancel()
+        if self.rx_conn:
+            self.rx_conn.close()
+        if self.tx_conn:
+            self.tx_conn.close()
+
+    def timeout(self):
+        self.done(error="Test timed out")
+
+    def on_start(self, event):
+        self.rx_conn = event.container.connect(self.router_address)
+        self.receiver  = event.container.create_receiver(self.rx_conn, self.target)
+        self.timer     = event.reactor.schedule(TIMEOUT, TestTimeout(self))
+
+    def on_link_opened(self, event):
+        if event.receiver:
+            assert self.tx_conn is None
+            self.tx_conn = event.container.connect(self.router_address)
+            self.tx_session = self.tx_conn.session()
+            # open initial session
+            self.tx_session.open()
+
+    def on_session_opened(self, event):
+        if event.session == self.tx_session:
+            self.tx_messages = 0
+            for index in range(self.tx_link_limit):
+                link = self.tx_session.sender(name=f"Link-{self.tx_session_count}-{index}")
+                link.target.address = self.target
+                link.open()
+                self.tx_links.append(link)
+
+    def on_link_flow(self, event):
+        if event.sender and event.sender in self.tx_links:
+            sender = event.sender
+            if sender.current is None and sender.credit > 0:
+                if self.tx_messages < self.tx_link_limit:
+                    sender.delivery(sender.delivery_tag())
+                    sender.stream(b'Mary had a little french bulldog')
+                    self.tx_messages += 1
+                    if self.tx_messages >= self.tx_link_limit:
+                        self.tx_session.close()
+
+    def on_session_closed(self, event):
+        if event.session == self.tx_session:
+            self.tx_session_count += 1
+            self.tx_links.clear()
+            if self.tx_session_count < self.tx_session_limit:
+                # repeat with new session
+                self.tx_session = self.tx_conn.session()
+                self.tx_session.open()
+            else:
+                # done
+                self.done()
 
     def run(self):
         Container(self).run()

--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -3469,9 +3469,9 @@ class AMQPSessionFlapTest(MessagingHandler):
 
 class AMQPLinkFlapTest(MessagingHandler):
     """
-    This test stresses the creation and deletion of AMQP links.
-    It repeatedly creates links, sends messages, and then tears the links down
-    while the messages are in flight.
+    This test stresses the creation and deletion of AMQP links.  It repeatedly
+    creates links then tears them down while keeping the parent connection
+    alive.
     """
     def __init__(self, router_address):
         super(AMQPLinkFlapTest, self).__init__()


### PR DESCRIPTION
Previously the detach handler might free the qd_link_t but it was not consistent. This patch moves the qd_link_t cleanup to the container.