### PR TITLE
Merge layers to shrink the container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -56,22 +56,20 @@ RUN mkdir /image/licenses && cp ./LICENSE /image/licenses
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # upgrade first to avoid fixable vulnerabilities
+# then install required packages
+# finally, remove gnutls etc. to reduce CVE exposure
+# https://github.com/skupperproject/skupper-router/issues/1477
+# https://github.com/skupperproject/skupper-router/issues/1639
 RUN microdnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
- && microdnf clean all -y
-
-RUN microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
+ && microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
     glibc \
     cyrus-sasl-lib cyrus-sasl-plain openssl \
     python3 \
     libnghttp2 \
     gettext hostname iputils \
     shadow-utils \
- && microdnf clean all
-
-# Remove gnutls, libarchive and everything that depends on it. 
-# https://github.com/skupperproject/skupper-router/issues/1477
-# https://github.com/skupperproject/skupper-router/issues/1639
-RUN microdnf -y remove gnutls glib2 gobject-introspection libpeas microdnf gnupg2 gpgme libdnf json-glib libmodulemd librepo librhsm libsolv rpm rpm-libs libarchive libyaml libusbx systemd-libs
+ && microdnf clean all \
+ && microdnf -y remove gnutls glib2 gobject-introspection libpeas microdnf gnupg2 gpgme libdnf json-glib libmodulemd librepo librhsm libsolv rpm rpm-libs libarchive libyaml libusbx systemd-libs
 
 RUN useradd --uid 10000 runner
 USER 10000


### PR DESCRIPTION
This merges all microdnf operations into a single layer, reducing the image from 280MiB to 226MiB. The old history shows

```
<missing>      19 minutes ago   RUN /bin/sh -c useradd --uid 10000 runner # …   3.48kB    buildkit.dockerfile.v0
<missing>      19 minutes ago   RUN /bin/sh -c microdnf -y remove gnutls gli…   22.3MB    buildkit.dockerfile.v0
<missing>      19 minutes ago   RUN /bin/sh -c microdnf -y --setopt=install_…   61.2MB    buildkit.dockerfile.v0
<missing>      19 minutes ago   RUN /bin/sh -c microdnf -y upgrade --refresh…   68.6MB    buildkit.dockerfile.v0
<missing>      6 months ago     /bin/sh -c mv -fZ /tmp/ubi.repo /etc/yum.rep…   98.6MB
```

The merged history shows

```
<missing>      10 minutes ago   RUN /bin/sh -c useradd --uid 10000 runner # …   3.48kB    buildkit.dockerfile.v0
<missing>      10 minutes ago   RUN /bin/sh -c microdnf -y upgrade --refresh…   98.7MB    buildkit.dockerfile.v0
<missing>      6 months ago     /bin/sh -c mv -fZ /tmp/ubi.repo /etc/yum.rep…   98.6MB
```