### PR TITLE
Set up the user in the packager stage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -63,13 +63,14 @@ RUN dnf -y --setopt=install_weak_deps=0 --nodocs \
     libnghttp2 \
     hostname iputils \
     shadow-utils \
+ && chroot /output useradd --uid 10000 runner \
+ && dnf -y --installroot /output remove shadow-utils \
  && dnf clean all --installroot /output
 
 FROM scratch
 
 COPY --from=packager /output /
 
-RUN useradd --uid 10000 runner
 USER 10000
 
 WORKDIR /


### PR DESCRIPTION
This allows shadow-utils to be removed in the final image, which reduces the exposure to CVEs in the relevant packages (shadow-utils and its dependencies). It also reduces the final image size by 3MiB.