### PR TITLE
Enable Clair security scanning on Quay

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -70,13 +70,13 @@ RUN dnf -y --setopt=install_weak_deps=0 --nodocs \
 FROM scratch
 
 COPY --from=packager /output /
+COPY --from=packager /etc/yum.repos.d /etc/yum.repos.d
+COPY --from=packager /root/buildinfo /root/buildinfo
 
 USER 10000
 
-WORKDIR /
 COPY --from=builder /image /
 
-WORKDIR /home/skrouterd/etc
 WORKDIR /home/skrouterd/bin
 COPY ./scripts/* /home/skrouterd/bin/
 


### PR DESCRIPTION
Since the router image was simplified, Quay reports scanning results, but these are misleading. It turns out that while Clair (the scanning tool used in Quay) can identify the packages shipped in the minimised images, it needs extra information to identify vulnerabilities in those packages; specifically, in UBI-based images, /root/buildinfo. See
https://github.com/quay/claircore/blob/main/rhel/repositoryscanner.go for reference.

This fixes that by copying the appropriate information from the "packager" image. While we're at it, copy the repository information too; this simplifies building further images on top of this one. Some WORKDIR statements are superfluous so those are removed too.