### PR TITLE
Fixes #1753: Expire Listener-side connection on certificate rotation

### DIFF
--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -44,19 +44,6 @@ typedef struct sys_mutex_t      sys_mutex_t;
  */
 
 /**
- * Deferred callback
- *
- * This type is for calls that are deferred until they can be invoked on
- * a specific connection's thread.
- *
- * @param context An opaque context to be passed back with the call.
- * @param discard If true, the call should be discarded because the connection it
- *        was pending on was deleted.
- */
-typedef void (*qd_deferred_t)(void *context, bool discard);
-
-
-/**
  * Run the server threads until completion - The blocking version.
  *
  * Start the operation of the server, including launching all of the worker

--- a/src/adaptors/amqp/amqp_adaptor.c
+++ b/src/adaptors/amqp/amqp_adaptor.c
@@ -58,7 +58,7 @@ static char *edge_role        = "edge";
 static char *inter_edge_role  = "inter-edge";
 
 
-static void deferred_AMQP_rx_handler(void *context, bool discard);
+static void deferred_AMQP_rx_handler(qd_connection_t *qd_conn, void *context, bool discard);
 static bool parse_failover_property_list(qd_router_t *router, qd_connection_t *conn, pn_data_t *props);
 static void clear_producer_activation(qdr_core_t *core, qdr_delivery_t *delivery);
 static void clear_consumer_activation(qdr_core_t *core, qdr_delivery_t *delivery);
@@ -981,7 +981,7 @@ static bool AMQP_rx_handler(qd_router_t *router, qd_link_t *link)
 /**
  * Deferred callback for inbound delivery handler
  */
-static void deferred_AMQP_rx_handler(void *context, bool discard)
+static void deferred_AMQP_rx_handler(qd_connection_t *qd_conn, void *context, bool discard)
 {
     qd_link_t_sp *safe_qdl = (qd_link_t_sp*) context;
 

--- a/src/adaptors/amqp/qd_listener.h
+++ b/src/adaptors/amqp/qd_listener.h
@@ -58,18 +58,46 @@ struct qd_listener_t {
 
 DEQ_DECLARE(qd_listener_t, qd_listener_list_t);
 
+/**
+ * Management call to create a qd_listener_t from a configuration entity.
+ *
+ * This provisions the listener but does not activate it. To start accepting new connections activate it by calling
+ * qd_listener_listen().
+ *
+ * Returns 0 and sets qd_error_code() if creation fails
+ */
+qd_listener_t *qd_listener_create(qd_dispatch_t *qd, qd_entity_t *entity);
+
+/**
+ * Management call to delete a listener.
+ *
+ * This deactivates the listener preventing it from accepting new incoming connections and drops the reference
+ * count. The listener pointer becomes invalid after this call.
+ *
+ * @param li the listener to delete
+ * @param on_shutdown true if the listener is being deleted as part of router shutdown
+ */
+void qd_listener_delete(qd_listener_t *li, bool on_shutdown);
+
+/**
+ * Drop a reference to the listener.
+ *
+ * The listener pointer becomes invalid on return from this call.
+ */
+void qd_listener_decref(qd_listener_t *li);
 
 /**
  * Listen for incoming connections, return true if listening succeeded.
  */
-bool qd_listener_listen(qd_listener_t *l);
-qd_listener_t *qd_listener(qd_server_t *server);
-void qd_listener_decref(qd_listener_t* ct);
-qd_lws_listener_t *qd_listener_http(const qd_listener_t *li);
+bool qd_listener_listen(qd_listener_t *li);
+
+// Read only access to the listeners configuration
+//
 const qd_server_config_t *qd_listener_config(const qd_listener_t *li);
 
-// add a new connection with the parent listener
-void qd_listener_add_connection(qd_listener_t *li, qd_connection_t *ctx);
+// add a new child connection to the parent listener
+//
+void qd_listener_add_connection(qd_listener_t *li, qd_connection_t *qd_conn);
 
 // remove the connection with its parent listener
 // NOTE WELL: may free the listener if this connection is holding the last reference

--- a/tests/system_tests_cert_rotation.py
+++ b/tests/system_tests_cert_rotation.py
@@ -27,6 +27,9 @@ from system_test import TestCase, main_module, Qdrouterd, unittest, retry
 from system_test import CA_CERT, SSL_PROFILE_TYPE
 from system_test import CLIENT_CERTIFICATE, CLIENT_PRIVATE_KEY, CLIENT_PRIVATE_KEY_PASSWORD
 from system_test import SERVER_CERTIFICATE, SERVER_PRIVATE_KEY, SERVER_PRIVATE_KEY_PASSWORD
+from system_test import CA2_CERT
+from system_test import CLIENT2_CERTIFICATE, CLIENT2_PRIVATE_KEY, CLIENT2_PRIVATE_KEY_PASSWORD
+from system_test import SERVER2_CERTIFICATE, SERVER2_PRIVATE_KEY, SERVER2_PRIVATE_KEY_PASSWORD
 from tcp_streamer import TcpStreamerThread
 
 
@@ -224,14 +227,14 @@ class InterRouterCertRotationTest(TestCase):
         router_L.teardown()
         router_C.teardown()
 
-    def test_03_tcp_streams(self):
+    def test_03_connector_tcp_streams(self):
         """
         Verify that existing TCP streams are not interrupted when new
         inter-router connections are established.
 
         This test sets up several TCP streaming connections through two
-        routers. It then does a certificate rotation and verifies that the
-        streams have not failed.
+        routers. It then does a connector-side certificate rotation and
+        verifies that the streams have not failed.
 
         It then creates another set of TCP streaming connections. It verifies
         that these streams are sent over the upgraded connections.
@@ -523,6 +526,199 @@ class InterRouterCertRotationTest(TestCase):
 
         tcp_streamer.join()
         new_tcp_streamer.join()
+
+        router_L.teardown()
+        router_C.teardown()
+
+    def test_05_listener_tcp_streams(self):
+        """
+        Similar to test_03_connector_tcp_streams but in this case the
+        connections are dropped due to advancing the oldestValidOrdinal on the
+        listener-side.
+
+        In this test the listener-side sslProfile will be rotated to a new
+        CA/certificate that are incompatible with the connector side. The
+        connector side will then be rotated to a compatible
+        CA/certificate. Then the older certificates will be expired on the
+        listener side.
+        """
+        data_conn_count = 4
+        inter_router_port = self.tester.get_port()
+        tcp_listener_port_1 = self.tester.get_port()
+        tcp_listener_port_2 = self.tester.get_port()
+        tcp_connector_port_1 = self.tester.get_port()
+        tcp_connector_port_2 = self.tester.get_port()
+
+        router_L = self.router("RouterL",
+                               [('sslProfile', {'name': 'ListenerSslProfile',
+                                                'caCertFile': CA_CERT,
+                                                'certFile': SERVER_CERTIFICATE,
+                                                'privateKeyFile': SERVER_PRIVATE_KEY,
+                                                'password': SERVER_PRIVATE_KEY_PASSWORD}),
+                                ('listener', {'name': 'Listener01',
+                                              'role': 'inter-router',
+                                              'host': '0.0.0.0',
+                                              'port': inter_router_port,
+                                              'requireSsl': 'yes',
+                                              'sslProfile': 'ListenerSslProfile'}),
+                                ('tcpListener', {'name': 'tcpListener01',
+                                                 'address': 'tcp/streaming/1',
+                                                 'port': tcp_listener_port_1}),
+                                ('tcpListener', {'name': 'tcpListener02',
+                                                 'address': 'tcp/streaming/2',
+                                                 'port': tcp_listener_port_2})],
+                               data_conn_count, wait=False)
+        router_C = self.router("RouterC",
+                               [('sslProfile', {'name': "ConnectorSslProfile",
+                                                'ordinal': 0,
+                                                'oldestValidOrdinal': 0,
+                                                'caCertFile': CA_CERT,
+                                                'certFile': CLIENT_CERTIFICATE,
+                                                'privateKeyFile': CLIENT_PRIVATE_KEY,
+                                                'password': CLIENT_PRIVATE_KEY_PASSWORD}),
+                                ('connector', {'role': 'inter-router',
+                                               'host': 'localhost',
+                                               'port': inter_router_port,
+                                               'verifyHostname': 'yes',
+                                               'sslProfile': 'ConnectorSslProfile'}),
+                                ('tcpConnector', {'name': 'tcpConnector01',
+                                                  'address': 'tcp/streaming/1',
+                                                  'host': 'localhost',
+                                                  'port': tcp_connector_port_1}),
+                                ('tcpConnector', {'name': 'tcpConnector02',
+                                                  'address': 'tcp/streaming/2',
+                                                  'host': 'localhost',
+                                                  'port': tcp_connector_port_2})],
+                               data_conn_count, wait=True)
+        router_C.wait_router_connected("RouterL")
+        router_L.wait_router_connected("RouterC")
+
+        # wait for all the inter-router data connections and the TCP listener
+        # ports to come up
+        self.wait_inter_router_conns(router_L, data_conn_count + 1)
+        wait_tcp_listeners_up(router_L.addresses[0])
+
+        # Verify all inter-router conns on Router_C are based on the same
+        # tlsOrdinal, which is zero.
+        ir_conns = router_C.get_inter_router_conns()
+        for ir_conn in ir_conns:
+            self.assertEqual(0, ir_conn['tlsOrdinal'])
+
+        # This test allows the certificate rotation to complete before expiring
+        # the old inter-router connections. Therefore we expect that the
+        # router's topology does not change during this test. Let the topology
+        # settle before continuting the test. Using the default flux_interval
+        # which should be "long enough" (fingers crossed)
+        flux_interval = 4.1  # wait a bit longer than the interval to prevent races
+        last_topo_C = router_C.get_last_topology_change()
+        last_topo_L = router_L.get_last_topology_change()
+        deadline = time.time() + flux_interval
+        while deadline > time.time():  # test will timeout on failure
+            time.sleep(0.1)
+            topo_C = router_C.get_last_topology_change()
+            topo_L = router_L.get_last_topology_change()
+            if topo_C != last_topo_C or topo_L != last_topo_L:
+                last_topo_C = topo_C
+                last_topo_L = topo_L
+                deadline = time.time() + flux_interval
+
+        # start TCP streaming connections across the routers
+        tcp_streamer = TcpStreamerThread(client_addr=('localhost', tcp_listener_port_1),
+                                         server_addr=('0.0.0.0', tcp_connector_port_1),
+                                         client_count=10, poll_timeout=0.2)
+
+        # Now wait until the streaming client have connected and traffic is
+        # being sent
+        ok = retry(lambda: tcp_streamer.active_clients == 10)
+        self.assertTrue(ok, f"Streaming clients failed {tcp_streamer.active_clients}")
+        begin_recv = tcp_streamer.bytes_received
+        ok = retry(lambda: tcp_streamer.bytes_received > begin_recv)
+        self.assertTrue(ok, f"Failed to stream data {tcp_streamer.bytes_received}")
+
+        # Expect 2 streaming links per TCP flow (links are uni-directional)
+        self.assertEqual(20, len(router_L.get_active_inter_router_data_links()),
+                         f"Failed to get 20 links: {router_L.get_active_inter_router_data_links()}")
+
+        # Now rotate the certs: Start on the listener side
+        router_L.management.update(type=SSL_PROFILE_TYPE,
+                                   attributes={'ordinal': 10,
+                                               'caCertFile': CA2_CERT,
+                                               'certFile': SERVER2_CERTIFICATE,
+                                               'privateKeyFile': SERVER2_PRIVATE_KEY,
+                                               'password': SERVER2_PRIVATE_KEY_PASSWORD},
+                                   name='ListenerSslProfile')
+
+        # And now the connector. This will result in a new set of inter-router
+        # connections that will replace the existing ones.
+        router_C.management.update(type=SSL_PROFILE_TYPE,
+                                   attributes={'ordinal': 11,
+                                               'caCertFile': CA2_CERT,
+                                               'certFile': CLIENT2_CERTIFICATE,
+                                               'privateKeyFile': CLIENT2_PRIVATE_KEY,
+                                               'password': CLIENT2_PRIVATE_KEY_PASSWORD},
+                                   name='ConnectorSslProfile')
+
+        # wait until the new control links are active and all the data
+        # connections have established
+        self.wait_inter_router_conns(router_L, 2 * (data_conn_count + 1))
+        ok = self.wait_control_links(router_C, 11)
+        self.assertTrue(ok, f"Bad control links: {router_C.get_active_inter_router_control_links()}")
+        ok = self.wait_control_links(router_L, 11)
+        self.assertTrue(ok, f"Bad control links: {router_L.get_active_inter_router_control_links()}")
+
+        # verify that the streamer is still running and the streams are still passing traffic
+        begin_recv = tcp_streamer.bytes_received
+        ok = retry(lambda: tcp_streamer.bytes_received > begin_recv)
+        self.assertTrue(ok, f"Failed to stream data {tcp_streamer.bytes_received}")
+        self.assertTrue(tcp_streamer.is_alive, "Streamer has failed!")
+
+        # Now create a new streamer. Its TCP flows should use the new
+        # inter-router-data links
+        new_tcp_streamer = TcpStreamerThread(client_addr=('localhost', tcp_listener_port_2),
+                                             server_addr=('0.0.0.0', tcp_connector_port_2),
+                                             client_count=4, poll_timeout=0.2)
+        ok = retry(lambda: new_tcp_streamer.active_clients == 4)
+        self.assertTrue(ok, f"Streaming clients failed {new_tcp_streamer.active_clients}")
+        begin_recv = new_tcp_streamer.bytes_received
+        ok = retry(lambda: new_tcp_streamer.bytes_received > begin_recv)
+        self.assertTrue(ok, f"Failed to stream data {new_tcp_streamer.bytes_received}")
+
+        # Expect an additional 2 streaming links per TCP flow (links are uni-directional)
+        self.assertEqual(28, len(router_L.get_active_inter_router_data_links()),
+                         f"Failed to get 28 links: {router_L.get_active_inter_router_data_links()}")
+
+        # Now expire the old inter-router connections by setting the listeners
+        # oldestValidOrdinal to 10. Expect the connections that carry the old
+        # streaming data to close.
+        router_L.management.update(type=SSL_PROFILE_TYPE,
+                                   attributes={'oldestValidOrdinal': 10},
+                                   name='ListenerSslProfile')
+        self.wait_inter_router_conns(router_C, data_conn_count + 1)
+        ok = retry(lambda: tcp_streamer.is_alive is False)
+        self.assertTrue(ok, "Failed to terminate the streamer")
+        tcp_streamer.join()
+
+        # Verify that the new TCP flows are still actively passing data
+        self.assertEqual(4, new_tcp_streamer.active_clients,
+                         f"New flows failed: {new_tcp_streamer.active_clients}")
+        begin_recv = new_tcp_streamer.bytes_received
+        ok = retry(lambda: new_tcp_streamer.bytes_received > begin_recv)
+        self.assertTrue(ok, f"Streaming data failed {new_tcp_streamer.bytes_received}")
+        new_tcp_streamer.join()
+
+        # Verify that the remaining inter-router conns (both data and control)
+        # share the group ordinal value (currently the same as the
+        # connector-side tlsOrdinal - may change in the future)
+        ir_conns = router_C.get_inter_router_conns()
+        ir_conns.extend(router_L.get_inter_router_conns())
+        for ir_conn in ir_conns:
+            self.assertEqual(11, ir_conn['groupOrdinal'], f"Wrong ordinal {ir_conn}")
+
+        # Lastly check that neither router has seen a topology change:
+        self.assertEqual(last_topo_C, router_C.get_last_topology_change(),
+                         "Unexpected topology change for RouterC")
+        self.assertEqual(last_topo_L, router_L.get_last_topology_change(),
+                         "Unexpected topology change for RouterL")
 
         router_L.teardown()
         router_C.teardown()


### PR DESCRIPTION
When an AMQP listener's sslProfile oldestValidOrdinal attribute is updated scan all connections that are children of that listener and check if the connection's tlsOrdinal value is less than the new oldestValidOrdinal value. If it is then close the connection.

Patch includes additional efforts to make the code fluffy:

1) Move qd_listener_t-specific code out of connection_manager.c and move it to the qd_listener.c file.
2) Modify the qd_connection_t deferred callback API to allow an extra context parameter to be passed to the callback. Hide the implementation details by moving the data structure from a header file into qd_connection.c.
3) Remove dead code.