### PR TITLE
Restore buildinfo with its new location

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -71,6 +71,7 @@ FROM scratch
 
 COPY --from=packager /output /
 COPY --from=packager /etc/yum.repos.d /etc/yum.repos.d
+COPY --from=packager /usr/share/buildinfo /usr/share/buildinfo
 
 USER 10000
 


### PR DESCRIPTION
The UBI base images now ship buildinfo in /usr/share rather than /root; this updates the container build to match.