### PR TITLE
Fixes #1793: Move the LINK vflow record from the connector object to …

### DIFF
--- a/src/adaptors/amqp/amqp_adaptor.c
+++ b/src/adaptors/amqp/amqp_adaptor.c
@@ -569,8 +569,8 @@ bool AMQP_rx_handler(qd_router_t *router, qd_link_t *link)
     //
     // Bump LINK metrics if appropriate
     //
-    if (!!conn->connector && !!conn->connector->vflow_record) {
-        vflow_inc_counter(conn->connector->vflow_record, VFLOW_ATTRIBUTE_OCTETS_REVERSE, (uint64_t) octets_received);
+    if (!!conn->connector && !!conn->connector->ctor_config && !!conn->connector->ctor_config->vflow_record) {
+        vflow_inc_counter(conn->connector->ctor_config->vflow_record, VFLOW_ATTRIBUTE_OCTETS_REVERSE, (uint64_t) octets_received);
     }
 
     // check if cut-through can be enabled or disabled
@@ -1535,8 +1535,8 @@ static void AMQP_opened_handler(qd_router_t *router, qd_connection_t *conn, bool
                            && strncmp(key.start, QD_CONNECTION_PROPERTY_ACCESS_ID, key.size) == 0)) {
                     props_found += 1;
                     if (!pn_data_next(props)) break;
-                    if (!!connector && !!connector->vflow_record && pn_data_type(props) == PN_STRING) {
-                        vflow_set_ref_from_pn(connector->vflow_record, VFLOW_ATTRIBUTE_PEER, props);
+                    if (!!connector && !!connector->ctor_config && !!connector->ctor_config->vflow_record && pn_data_type(props) == PN_STRING) {
+                        vflow_set_ref_from_pn(connector->ctor_config->vflow_record, VFLOW_ATTRIBUTE_PEER, props);
                     }
 
                 } else {
@@ -2143,8 +2143,8 @@ static uint64_t CORE_link_deliver(void *context, qdr_link_t *link, qdr_delivery_
     //
     // Bump LINK metrics if appropriate
     //
-    if (!!qconn->connector && !!qconn->connector->vflow_record) {
-        vflow_inc_counter(qconn->connector->vflow_record, VFLOW_ATTRIBUTE_OCTETS, (uint64_t) octets_sent);
+    if (!!qconn->connector && !!qconn->connector->ctor_config && !!qconn->connector->ctor_config->vflow_record) {
+        vflow_inc_counter(qconn->connector->ctor_config->vflow_record, VFLOW_ATTRIBUTE_OCTETS, (uint64_t) octets_sent);
     }
 
     //

--- a/src/adaptors/amqp/qd_connector.h
+++ b/src/adaptors/amqp/qd_connector.h
@@ -64,7 +64,6 @@ typedef struct qd_connector_t {
     sys_mutex_t               lock;
     connector_state_t         state;
     qd_connection_t          *qd_conn;
-    vflow_record_t           *vflow_record;
     bool                      oper_status_down;  // set when oper-status transitions to 'down' to avoid repeated error indications.
     bool                      is_data_connector; // inter-router conn for streaming messages
 
@@ -96,13 +95,13 @@ struct qd_connector_config_t {
     qd_server_t              *server;
     char                     *policy_vhost;  /* Optional policy vhost name */
     qd_timer_t               *cleanup_timer; /* remove quiesced connectors */
-
+    vflow_record_t           *vflow_record; /* vflow record for VFLOW_RECORD_LINK */
     // TLS Configuration. Keep a local copy of the TLS ordinals to monitor changes by management
     qd_tls_config_t          *tls_config;
     uint64_t                  tls_ordinal;
     uint64_t                  tls_oldest_valid_ordinal;
     uint32_t                  data_connection_count;  // # of child inter-router data connections
-
+    sys_atomic_t              active_control_conn_count;
     // The group correlation id for all child connectors/connections
     char                      group_correlator[QD_DISCRIMINATOR_SIZE];
 

--- a/tests/vanflow_snooper.py
+++ b/tests/vanflow_snooper.py
@@ -127,7 +127,8 @@ attribute_types = {
     62: "PROXY_HOST",
     63: "PROXY_PORT",
     64: "ERROR_LISTENER_SIDE",
-    65: "ERROR_CONNECTOR_SIDE"
+    65: "ERROR_CONNECTOR_SIDE",
+    66: "ACTIVE_TLS_ORDINAL"
 }
 
 


### PR DESCRIPTION
…connector_config object. This ensures

that only one LINK record exists per logical link