### PR TITLE
Fixes #1790: When a PN_TRANSPORT_ERROR event is received, immediately…

### DIFF
--- a/src/adaptors/amqp/qd_connection.c
+++ b/src/adaptors/amqp/qd_connection.c
@@ -821,6 +821,8 @@ bool qd_connection_handle_event(qd_server_t *qd_server, pn_event_t *e, void *con
                            pn_condition_get_description(condition));
                 }
             }
+            pn_connection_write_flush(pn_conn);
+            pn_transport_close_head(transport);
         }
         break;
 

--- a/tests/system_tests_tcp_adaptor.py
+++ b/tests/system_tests_tcp_adaptor.py
@@ -1298,6 +1298,7 @@ class TcpAdaptorStuckDeliveryTest(TestCase):
             server.bind(("", self.interior_tcp_connector_port))
             server.listen(10)
         except Exception as exc:
+            server.close()
             print("%s: failed creating tcp server: %s" % (self.test_name, exc),
                   flush=True)
             raise
@@ -1834,6 +1835,7 @@ class TcpAdaptorListenerConnectTest(TestCase):
                         # There may be a delay between the operStatus going up and
                         # the actual listener socket availability, so allow that:
                         time.sleep(0.1)
+                        client_conn.close()
                         continue
 
                     server_conn, _ = server.accept()
@@ -1864,6 +1866,7 @@ class TcpAdaptorListenerConnectTest(TestCase):
                     continue
                 except ConnectionRefusedError:
                     # Test successful
+                    client_conn.close()
                     break
 
         l_mgmt.delete(type=TCP_LISTENER_TYPE, name=listener_name)


### PR DESCRIPTION
… call pn_connection_write_flush(conn) and pn_transport_close_head(tport). This will immediately generate the PN_TRANSPORT_CLOSE event. We have observed sometimes that the PN_TRANSPORT_ERROR event is not immediately followed by a PN_TRANSPORT_CLOSED event and this will remedy that situation