### PR TITLE
Fixes #1804 - Fix the default hosts for tcpListener and tcpConnector.

### DIFF
--- a/python/skupper_router/management/skrouter.json
+++ b/python/skupper_router/management/skrouter.json
@@ -1080,7 +1080,7 @@
                 "host": {
                     "description":"A host name, IPV4 or IPV6 literal, or the empty string. The empty string listens on all local addresses. A host name listens on all addresses associated with the name. An IPV6 literal address (or wildcard '[::]') listens only for IPV6. An IPV4 literal address (or wildcard '0.0.0.0') listens only for IPV4.",
                     "type": "string",
-                    "default": "0.0.0.0",
+                    "default": "",
                     "create": true
                 },
                 "backlog": {
@@ -1160,6 +1160,7 @@
                 },
                 "host": {
                     "description":"IP address: ipv4 or ipv6 literal or a host name",
+                    "default": "127.0.0.1",
                     "type": "string",
                     "create": true
                 },

--- a/src/adaptors/amqp/server_config.c
+++ b/src/adaptors/amqp/server_config.c
@@ -75,16 +75,9 @@ static void load_strip_annotations(qd_server_config_t *config, const char* strip
     }
 }
 
-
-/**
- * Since both the host and the addr have defaults of 127.0.0.1, we will have to use the non-default wherever it is
- * available.
- */
 static void set_config_host(qd_server_config_t *config, qd_entity_t* entity)
 {
-    config->host = qd_entity_opt_string(entity, "host", 0);
-
-    assert(config->host);
+    config->host = qd_entity_get_string(entity, "host");
 
     int hplen = strlen(config->host) + strlen(config->port) + 2;
     config->host_port = malloc(hplen);


### PR DESCRIPTION
This PR makes the host defaults in tcpListener and tcpConnector the same as those in listener and connector.

There should be no backward compatibility problems with this change because the behavior of the tcpListener will be the same in IPv4-only environments and mixed environments.  In IPv6-only environments, tcpListener did not work for all-hosts (only if a specific IPv6 address was configured) but will now work.