### PR TITLE
Fixes #1828 - Create a new management entity managedRouter

### DIFF
--- a/python/skupper_router/management/skrouter.json
+++ b/python/skupper_router/management/skrouter.json
@@ -499,7 +499,6 @@
             }
         },
 
-
         "router": {
             "description":"Tracks peer routers and computes routes to destinations. This entity is mandatory. The router will not start without this entity.",
             "extends": "configurationEntity",
@@ -512,7 +511,7 @@
                     "create": true
                 },
                 "vanId": {
-                    "description":"The unique ID of the Virtual Application Network that this router is a member of.",
+                    "description":"Deprecated:  See the managedRouter entity definition.",
                     "type": "string",
                     "required": false,
                     "create": true
@@ -634,6 +633,20 @@
             }
         },
 
+        "managedRouter": {
+            "description": "This optional entity holds configuration needed for the router to be managed by a central manager",
+            "extends": "configurationEntity",
+            "singleton": true,
+            "attributes": {
+                "vanId": {
+                    "description":"The unique ID of the Virtual Application Network that this router is a member of.",
+                    "type": "string",
+                    "required": false,
+                    "create": true
+                }
+            }
+        },
+
         "site": {
             "description":"Optional.  If present, this entity causes the router to emit a SITE record for VanFLow in the case that there is not an external controller to emit this record.",
             "extends": "configurationEntity",
@@ -670,6 +683,7 @@
                 }
             }
         },
+
         "sslProfile": {
             "description":"Attributes for setting TLS/SSL configuration for connections.",
             "referential": true,

--- a/python/skupper_router_internal/dispatch.py
+++ b/python/skupper_router_internal/dispatch.py
@@ -103,6 +103,7 @@ class QdDll(PyDLL):
         self._prototype(self.qd_error_code, c_long, [], check=False)
         self._prototype(self.qd_error_message, c_char_p, [], check=False)
         self._prototype(self.qd_log_entity, c_long, [py_object])
+        self._prototype(self.qd_dispatch_configure_managed_router, None, [self.qd_dispatch_p, py_object])
         self._prototype(self.qd_dispatch_configure_router, None, [self.qd_dispatch_p, py_object])
         self._prototype(self.qd_dispatch_configure_site, None, [self.qd_dispatch_p, py_object])
         self._prototype(self.qd_dispatch_prepare, None, [self.qd_dispatch_p])

--- a/python/skupper_router_internal/management/agent.py
+++ b/python/skupper_router_internal/management/agent.py
@@ -280,6 +280,17 @@ class RouterEntity(EntityAdapter):
         return super(RouterEntity, self).__str__().replace("Entity(", "RouterEntity(")
 
 
+class ManagedRouterEntity(EntityAdapter):
+    def __init__(self, agent, entity_type, attributes=None):
+        super(ManagedRouterEntity, self).__init__(agent, entity_type, attributes, validate=False)
+
+    def create(self):
+        self._qd.qd_dispatch_configure_managed_router(self._dispatch, self)
+
+    def __str__(self):
+        return super(ManagedRouterEntity, self).__str__().replace("Entity(", "ManagedRouterEntity(")
+
+
 class SiteEntity(EntityAdapter):
     def __init__(self, agent, entity_type, attributes=None):
         super(SiteEntity, self).__init__(agent, entity_type, attributes, validate=False)

--- a/python/skupper_router_internal/management/config.py
+++ b/python/skupper_router_internal/management/config.py
@@ -304,6 +304,7 @@ def configure_dispatch(dispatch_int: int, filename: str) -> None:
 
     # Configure and prepare the router before we can activate the agent.
     configure(config.by_type('router')[0])
+    configure(config.by_type('managedRouter')[0])
     qd.qd_dispatch_prepare(dispatch)
     qd.qd_router_setup_late(dispatch)  # Actions requiring active management agent.
     agent.activate("$_management_internal")

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -219,11 +219,24 @@ static void qd_dispatch_set_router_default_distribution(qd_dispatch_t *qd, char 
     free(distribution);
 }
 
+qd_error_t qd_dispatch_configure_managed_router(qd_dispatch_t *qd, qd_entity_t *entity)
+{
+    char *van_id = qd_entity_opt_string(entity, "vanId", 0); QD_ERROR_RET();
+    if (van_id) {
+        qd_dispatch_set_router_van_id(qd, van_id);
+    }
+    return QD_ERROR_NONE;
+}
+
 qd_error_t qd_dispatch_configure_router(qd_dispatch_t *qd, qd_entity_t *entity)
 {
     qd_dispatch_set_router_default_distribution(qd, qd_entity_opt_string(entity, "defaultDistribution", 0)); QD_ERROR_RET();
     qd_dispatch_set_router_id(qd, qd_entity_opt_string(entity, "id", 0)); QD_ERROR_RET();
-    qd_dispatch_set_router_van_id(qd, qd_entity_opt_string(entity, "vanId", 0)); QD_ERROR_RET();
+    char *van_id = qd_entity_opt_string(entity, "vanId", 0); QD_ERROR_RET();
+    if (van_id) {
+        qd_dispatch_set_router_van_id(qd, van_id);
+        qd_log(LOG_ROUTER, QD_LOG_WARNING, "The vanId attribute is deprecated in the router entity.  Please move it to managedRouter.");
+    }
     qd->router_mode = qd_entity_get_long(entity, "mode"); QD_ERROR_RET();
     if (!qd->router_id) {
         char *mode = 0;
@@ -277,7 +290,6 @@ qd_error_t qd_dispatch_configure_router(qd_dispatch_t *qd, qd_entity_t *entity)
     }
 
     return QD_ERROR_NONE;
-
 }
 
 qd_error_t qd_dispatch_configure_address(qd_dispatch_t *qd, qd_entity_t *entity) {

--- a/tests/system_tests_skmanage.py
+++ b/tests/system_tests_skmanage.py
@@ -38,7 +38,7 @@ from system_test import CA_CERT, SERVER_CERTIFICATE, SERVER_PRIVATE_KEY, SERVER_
     CLIENT_CERTIFICATE, CLIENT_PASSWORD_FILE, CLIENT_PRIVATE_KEY
 CONNECTION_PROPERTIES_UNICODE_STRING = {'connection': 'properties', 'int_property': 6451}
 
-TOTAL_ENTITIES = 28   # for tests that check the total # of entities
+TOTAL_ENTITIES = 29   # for tests that check the total # of entities
 
 
 class SkmanageTest(TestCase):


### PR DESCRIPTION
Move vanId from router to managedRouter, deprecate the old location.