### PR TITLE
Support service listeners with multiple addresses

### DIFF
--- a/docs/notes/multi-key-tcp-listeners.md
+++ b/docs/notes/multi-key-tcp-listeners.md
@@ -1,0 +1,53 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one -->
+<!-- or more contributor license agreements.  See the NOTICE file -->
+<!-- distributed with this work for additional information -->
+<!-- regarding copyright ownership.  The ASF licenses this file -->
+<!-- to you under the Apache License, Version 2.0 (the -->
+<!-- "License"); you may not use this file except in compliance -->
+<!-- with the License.  You may obtain a copy of the License at -->
+
+<!--   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- Unless required by applicable law or agreed to in writing, -->
+<!-- software distributed under the License is distributed on an -->
+<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!-- KIND, either express or implied.  See the License for the -->
+<!-- specific language governing permissions and limitations -->
+<!-- under the License. -->
+
+# Multi address tcp listeners
+
+An ordinary tcp listener has exactly one service address associated with it. The address is defined at listener creation time and cannot be changed afterwards. The service address determines the potential target connectors for each new client connection of the tcp listener.
+
+A multi address listener can have more than one service addresses. No address is defined at creation time. Instead, addresses can be assigned to or removed from the multi address listener dynamically during its entire lifespan. A new client connection always picks an optimal target address from the current set of addresses. There is a new listener property to define an address selection strategy. This strategy determines the criteria for selecting the optimal address for a new client connection.
+
+## Router Configuration
+
+The router management schema is extended as follows.
+
+* A new field called `multiAddressStrategy` is added to the tcpListener  configuration entity. It defines the address selection strategy.
+* A new configuration entity called `listenerAddress` is added to the schema. This entity associates a new service address with an existing multi key listener.
+
+### Address selection strategy
+
+The new `multiAddressStrategy` field in the tcpListener entity can take the following values:
+
+* `none`: No address selection strategy is defined for the listener. This value indicates that it is an ordinary listener which has exactly one address. The address is defined in the address field of the listener entity. This is the default value.
+* `priority`: Indicates a multi address listener. The `address` field of the listener entity is ignored. This address selection strategy always picks the address with the highest priority value from the current set of reachable addresses. Note that this is the only supported address selection strategy currently.
+
+### New listener address entity
+
+The new listenerAddress entity has the following fields.
+
+* `address`: The service address (a.k.a. routing key) value.
+* `value`: An integer parameter. The priority address selection strategy interprets this value as priority. Larger values represent higher priority.
+* `listener`: The name of the listener which this service address is to be associated with. The referred listener must already exist.
+
+The `listenerAddress` entity supports `create` and `delete` operations. Service address entities can be created and deleted dynamically during the lifespan of the corresponding multi address listener.
+
+## Implementation notes
+
+* Deletion of a service address entity does not affect already existing client connections targeting that address.
+* If multiple service addresses share the same value, those addresses will be ordered non-deterministically by the router. I.e. if there are two addresses with the same value, and that value is the highest priority, and both addresses are reachable, the router will arbitrarily choose one of those addresses to be treated as the currently highest priority address.
+* Each listener address holds a reference to the parent listener adaptor hence it is not allowed to delete a multi-address listener if it has any associated address.
+* A vanflow record of type `VFLOW_RECORD_LISTENER`is created for each individual address of a multi-address listener. The record begins and ends when the address is created and deleted, respectively. Vanflow records of the same multi-address listener have the same listener name.

--- a/python/skupper_router/management/skrouter.json
+++ b/python/skupper_router/management/skrouter.json
@@ -1109,6 +1109,12 @@
                     "type": "string",
                     "create": true
                 },
+                "multiAddressStrategy": {
+                    "description": "Connection target address selection strategy for multi-address listener. If not 'none', the 'address' field is ignored and multiple service addresses can be specified for the listener by creating 'listenerAddress' entities. The strategy value determines how new connections select a target address. The only supported value is 'priority' currently.  Priority strategy always selects the address with the highest priority value from the current set of reachable addresses.",
+                    "type": ["none", "priority"],
+                    "default": "none",
+                    "create": true
+                },
                 "siteId": {
                     "type": "string",
                     "required": false,
@@ -1234,6 +1240,32 @@
                 }
             }
         },
+
+        "listenerAddress" : {
+           "description": "Configure a service address for a multi-address 'tcpListener'. The corresponding 'tcpListener' must specify the strategy for selecting target addresses for new connections.",
+            "extends": "configurationEntity",
+            "operations": ["CREATE", "DELETE"],
+            "attributes": {
+                "address": {
+                    "description":"Service address.",
+                    "type": "string",
+                    "create": true,
+                    "required": true
+                },
+                "value": {
+                    "description":"Address selection strategy-specific numeric value (priority, etc.).",
+                    "type": "integer",
+                    "create": true,
+                    "required": true
+                },
+                "listener": {
+                    "description":"Name of the 'tcpListener' this address belongs to.",
+                    "type": "string",
+                    "create": true,
+                    "required": true
+                }
+            }
+       },
 
         "log": {
             "description": "Configure logging for a particular module. You can use the `UPDATE` operation to change log settings while the router is running.",

--- a/python/skupper_router_internal/dispatch.py
+++ b/python/skupper_router_internal/dispatch.py
@@ -110,8 +110,10 @@ class QdDll(PyDLL):
 
         # tcp and amqp listeners
         self._prototype(self.qd_dispatch_configure_tcp_listener, c_void_p, [self.qd_dispatch_p, py_object])
-        self._prototype(self.qd_dispatch_delete_tcp_listener, None, [self.qd_dispatch_p, c_void_p])
+        self._prototype(self.qd_dispatch_delete_tcp_listener, c_long, [self.qd_dispatch_p, c_void_p])
         self._prototype(self.qd_dispatch_update_tcp_listener, c_void_p, [self.qd_dispatch_p, py_object, c_void_p])
+        self._prototype(self.qd_dispatch_configure_tcp_listener_address, c_void_p, [self.qd_dispatch_p, py_object])
+        self._prototype(self.qd_dispatch_delete_tcp_listener_address, None, [self.qd_dispatch_p, c_void_p])
         self._prototype(self.qd_dispatch_configure_listener, c_void_p, [self.qd_dispatch_p, py_object])
         self._prototype(self.qd_connection_manager_delete_listener, None, [self.qd_dispatch_p, c_void_p])
 

--- a/python/skupper_router_internal/management/agent.py
+++ b/python/skupper_router_internal/management/agent.py
@@ -470,6 +470,24 @@ class ListenerEntity(ConnectionBaseEntity):
         self._qd.qd_connection_manager_delete_listener(self._dispatch, self._implementations[0].key)
 
 
+class ListenerAddressEntity(EntityAdapter):
+    def create(self):
+        config_listener_address = self._qd.qd_dispatch_configure_tcp_listener_address(self._dispatch, self)
+        return config_listener_address
+
+    def _identifier(self):
+        if self.attributes.get('name') is not None:
+            return "%s:%s:%s" % (self.listener, self.address, self.name)
+        else:
+            return "%s:%s" % (self.listener, self.address)
+
+    def __str__(self):
+        return super(ListenerAddressEntity, self).__str__().replace("Entity(", "ListenerAddressEntity(")
+
+    def _delete(self):
+        self._qd.qd_dispatch_delete_tcp_listener_address(self._dispatch, self._implementations[0].key)
+
+
 class ConnectorEntity(ConnectionBaseEntity):
     def __init__(self, agent, entity_type, attributes=None, validate=True):
         super(ConnectorEntity, self).__init__(agent, entity_type, attributes,
@@ -556,7 +574,9 @@ class TcpListenerEntity(EntityAdapter):
         return config_listener
 
     def _delete(self):
-        self._qd.qd_dispatch_delete_tcp_listener(self._dispatch, self._implementations[0].key)
+        err = self._qd.qd_dispatch_delete_tcp_listener(self._dispatch, self._implementations[0].key)
+        if err:
+            raise BadRequestStatus("Listener cannot be deleted: %s" % self._qd_error_message())
 
     def _update(self):
         tmp = self._qd.qd_dispatch_update_tcp_listener(self._dispatch, self, self._implementations[0].key)

--- a/python/skupper_router_internal/management/config.py
+++ b/python/skupper_router_internal/management/config.py
@@ -342,7 +342,8 @@ def configure_dispatch(dispatch_int: int, filename: str) -> None:
         if not e['type'] in ['io.skupper.router.connector',
                              'io.skupper.router.listener',
                              'io.skupper.router.tcpListener',
-                             'io.skupper.router.tcpConnector']:
+                             'io.skupper.router.tcpConnector',
+                             'io.skupper.router.listenerAddress']:
             configure(e)
 
     # Load the vhosts from the .json files in policyDir
@@ -358,6 +359,6 @@ def configure_dispatch(dispatch_int: int, filename: str) -> None:
     # Static configuration is loaded except for connectors and listeners.
     # Configuring connectors and listeners last starts inter-router and user messages
     # when the router is in a known and repeatable initial configuration state.
-    for t in "connector", "listener", "tcpListener", "tcpConnector":
+    for t in "connector", "listener", "tcpListener", "tcpConnector", "listenerAddress":
         for a in config.by_type(t):
             configure(a)

--- a/src/adaptors/adaptor_common.h
+++ b/src/adaptors/adaptor_common.h
@@ -48,6 +48,7 @@ struct qd_adaptor_config_t
     char                       *name;
     char                       *host;
     char                       *port;
+    char                       *multi_address_strategy;
     char                       *address;
     char                       *site_id;
     char                       *host_port;
@@ -62,8 +63,20 @@ struct qd_adaptor_config_t
 
 ALLOC_DECLARE(qd_adaptor_config_t);
 
+typedef struct qd_listener_address_config_t qd_listener_address_config_t;
+
+// Address config for multi-address listeners
+struct qd_listener_address_config_t {
+    char *address;
+    int   value;
+    char *listener_name;
+};
+
 qd_error_t qd_load_adaptor_config(qdr_core_t *core, qd_adaptor_config_t *config, qd_entity_t *entity);
 void qd_free_adaptor_config(qd_adaptor_config_t *config);
+
+qd_error_t qd_load_listener_address_config(qdr_core_t *core, qd_listener_address_config_t *config, qd_entity_t *entity);
+void       qd_clear_listener_address_config(qd_listener_address_config_t *config);
 
 /**
  * Get the raw connections remote address.

--- a/src/adaptors/adaptor_listener.c
+++ b/src/adaptors/adaptor_listener.c
@@ -27,6 +27,30 @@
 #include <proton/listener.h>
 #include <proton/proactor.h>
 
+// Address selection strategies for multi-address listener
+const char *ADDRESS_STRATEGY_PRIORITY = "priority";
+
+typedef enum {
+    QD_ADDR_STRATEGY_NONE,
+    QD_ADDR_STRATEGY_PRIORITY // select address with highest priority
+} qd_multi_address_strategy_t;
+
+struct qd_listener_address_t
+{
+    DEQ_LINKS(qd_listener_address_t);
+    char                  *address;
+    int                    priority;
+    sys_atomic_t           ref_count;
+    qdr_watch_handle_t     addr_watcher;
+    bool                   reachable; // true if there is at least one active consumer
+    qd_adaptor_listener_t *listener; // needed by the address watcher callbacks
+    uint64_t               connections_opened;
+    vflow_record_t        *vflow;
+};
+
+ALLOC_DEFINE(qd_listener_address_t);
+DEQ_DECLARE(qd_listener_address_t, qd_listener_address_list_t);
+
 struct qd_adaptor_listener_t {
 
     // the following fields are mutably shared between multiple threads and
@@ -38,19 +62,21 @@ struct qd_adaptor_listener_t {
     qd_listener_oper_status_t     oper_status;
     char                         *error_message;
     int                           ref_count;
-    bool                          watched;
+    qd_listener_address_list_t    addresses;
+    qd_multi_address_strategy_t   address_strategy;
+    uint32_t                      reachable_address_count;
 
     // the following fields are immutable so they may be accessed without
     // holding the lock:
 
     const qd_dispatch_t          *qd;
     void                         *user_context;
-    char                         *service_address;
     char                         *name;
+    char                         *host;
+    char                         *port;
     char                         *host_port;
     qd_log_module_t               log_module;
     qd_handler_context_t          event_handler;
-    qdr_watch_handle_t            addr_watcher;
     int                           backlog;
 
     // must hold _listeners_lock:
@@ -92,12 +118,32 @@ static void _set_error_message_LH(qd_adaptor_listener_t *li, const char *m)
     }
 }
 
+static void _listener_address_free(qd_listener_address_t *addr) {
+    assert(!DEQ_NEXT(addr) && !DEQ_PREV(addr));
+
+    // This function can be called from listener adaptor finalize when the
+    // vanflow adaptor is gone already. Vanflow record must be ended before
+    // we get here.
+    assert(!addr->vflow);
+
+    free(addr->address);
+    free_qd_listener_address_t(addr);
+}
+
 // called during shutdown: must not schedule work!
 static void _listener_free(qd_adaptor_listener_t *li)
 {
+    qd_listener_address_t *addr = 0;
+    while ((addr = DEQ_HEAD(li->addresses)))  {
+        DEQ_REMOVE_HEAD(li->addresses);
+        _listener_address_free(addr);
+    }
+
     free(li->name);
+    free(li->host);
+    free(li->port);
     free(li->host_port);
-    free(li->service_address);
+
     free(li->error_message);
     sys_mutex_free(&li->lock);
     free_qd_adaptor_listener_t(li);
@@ -210,6 +256,7 @@ static void _listener_event_handler(pn_event_t *e, qd_server_t *qd_server, void 
             li->pn_listener = 0;
 
             bool re_created = false;
+            qd_listener_address_t *addr = 0;
             if (li->admin_status == QD_LISTENER_ADMIN_ENABLED) {
                 // close is due to loss of available consumers - see
                 // _on_watched_address_update()
@@ -218,6 +265,12 @@ static void _listener_event_handler(pn_event_t *e, qd_server_t *qd_server, void 
                     // new consumers arrived since the close was
                     // started. Re-establish the listening socket:
                     re_created = true;
+
+                    addr = DEQ_HEAD(li->addresses);
+                    DEQ_FIND(addr, addr->reachable);
+                    assert(addr);
+                    sys_atomic_inc(&addr->ref_count); // temporary ref for the log record below
+
                     li->pn_listener = pn_listener();
                     pn_listener_set_context(li->pn_listener, &li->event_handler);
                     li->ref_count += 1;  // reference via pn_listener context
@@ -233,7 +286,8 @@ static void _listener_event_handler(pn_event_t *e, qd_server_t *qd_server, void 
 
             if (re_created) {
                 qd_log(log_module, QD_LOG_DEBUG, "Re-creating listener %s socket on address %s for service address %s",
-                       li->name, li->host_port, li->service_address);
+                       li->name, li->host_port, addr->address);
+                qd_adaptor_listener_address_decref(addr); // drop temporary reference
             }
 
             _listener_decref(li);  // drop temporary reference
@@ -268,21 +322,33 @@ static void _on_watched_address_update(void     *context,
         // the address watch holds a reference count to the listener so it cannot be
         // deleted during this call
         //
-        qd_adaptor_listener_t *li = (qd_adaptor_listener_t*) context;
+        qd_listener_address_t *addr = (qd_listener_address_t*) context;
+        assert(addr);
+        qd_adaptor_listener_t *li = addr->listener;
+        assert(li);
 
         qd_log(li->log_module, QD_LOG_DEBUG,
                "Listener %s (%s) service address %s consumer count updates:"
                " local=%" PRIu32 " in-process=%" PRIu32 " remote=%" PRIu32,
-               li->name, li->host_port, li->service_address, local_consumers, in_proc_consumers, remote_consumers);
+               li->name, li->host_port, addr->address, local_consumers, in_proc_consumers, remote_consumers);
 
         sys_mutex_lock(&li->lock);
 
         bool created = false;
         bool stopped = false;
         if (li->admin_status == QD_LISTENER_ADMIN_ENABLED) {
-            const bool can_listen = (local_consumers || remote_consumers || in_proc_consumers);
+            const bool has_consumers = (local_consumers || remote_consumers || in_proc_consumers);
 
-            if (can_listen) {
+            if (addr->reachable && !has_consumers) {
+                addr->reachable = false;
+                assert(li->reachable_address_count > 0);
+                li->reachable_address_count--;
+            } else if (!addr->reachable && has_consumers) {
+                addr->reachable = true;
+                li->reachable_address_count++;
+            }
+
+            if (li->reachable_address_count > 0) {
                 if (li->oper_status == QD_LISTENER_OPER_DOWN) {
                     li->oper_status = QD_LISTENER_OPER_OPENING;
                     if (!li->pn_listener) {
@@ -309,15 +375,25 @@ static void _on_watched_address_update(void     *context,
             }
         }
 
+        if (li->address_strategy != QD_ADDR_STRATEGY_NONE && (stopped || created)) {
+            // temporary reference to prevent freeing the address while writing the log message below
+            sys_atomic_inc(&addr->ref_count);
+        }
+
         sys_mutex_unlock(&li->lock);
 
         if (stopped)
             qd_log(li->log_module, QD_LOG_DEBUG, "Closing listener %s (%s) socket: no service available for address %s",
-                   li->name, li->host_port, li->service_address);
+                   li->name, li->host_port, addr->address);
 
         else if (created)
             qd_log(li->log_module, QD_LOG_DEBUG, "Creating listener %s (%s) socket for service address %s", li->name,
-                   li->host_port, li->service_address);
+                   li->host_port, addr->address);
+
+        if (li->address_strategy != QD_ADDR_STRATEGY_NONE && (stopped || created)) {
+            // release temporary reference
+            qd_adaptor_listener_address_decref(addr);
+        }
     }
 }
 
@@ -325,13 +401,35 @@ static void _on_watched_address_update(void     *context,
 static void _on_watched_address_cancel(void *context)
 {
     if (!_finalized) {
-        qd_adaptor_listener_t *li = (qd_adaptor_listener_t*) context;
+        qd_listener_address_t *addr = (qd_listener_address_t*) context;
+        qd_adaptor_listener_t *li = addr->listener;
 
         sys_mutex_lock(&li->lock);
-        if (li->pn_listener) {
-            pn_listener_close(li->pn_listener);
+
+        if (addr->reachable) {
+            assert(li->reachable_address_count > 0);
+            li->reachable_address_count--;
         }
+
+        bool stopped = false;
+        if (!li->reachable_address_count) {
+            if (li->oper_status != QD_LISTENER_OPER_DOWN)
+                li->oper_status = QD_LISTENER_OPER_DOWN;
+            if (li->pn_listener) {
+                stopped = true;
+                pn_listener_close(li->pn_listener);
+            }
+        }
+
+        DEQ_REMOVE(li->addresses, addr);
+
         sys_mutex_unlock(&li->lock);
+
+        if (stopped)
+            qd_log(li->log_module, QD_LOG_DEBUG, "Closing listener %s (%s) socket: no service available for address %s",
+                   li->name, li->host_port, addr->address);
+
+        qd_adaptor_listener_address_decref(addr);
 
         _listener_decref(li);
     }
@@ -357,10 +455,27 @@ qd_adaptor_listener_t *qd_adaptor_listener(const qd_dispatch_t       *qd,
     li->ref_count = 1;  // for caller
     li->qd = qd;
     li->name = qd_strdup(config->name);
-    li->host_port = qd_strdup(config->host_port);
-    li->service_address = qd_strdup(config->address);
-    li->backlog         = config->backlog;
-    li->log_module      = module;
+    li->host = qd_strdup(config->host);
+    li->port = qd_strdup(config->port);
+    li->host_port  = qd_strdup(config->host_port);
+    li->backlog    = config->backlog;
+    li->log_module = module;
+
+    if (!!config->multi_address_strategy &&
+        !strcmp(config->multi_address_strategy, ADDRESS_STRATEGY_PRIORITY)) {
+        assert(!config->address);
+        li->address_strategy = QD_ADDR_STRATEGY_PRIORITY;
+    }
+
+    if (li->address_strategy == QD_ADDR_STRATEGY_NONE) {
+        // this is a single address listener
+        qd_listener_address_t *addr = new_qd_listener_address_t();
+        ZERO(addr);
+        sys_atomic_init(&addr->ref_count, 1);
+        addr->address   = qd_strdup(config->address);
+        addr->listener  = li;
+        DEQ_INSERT_HEAD(li->addresses, addr);
+    }
 
     sys_mutex_init(&li->lock);
     li->admin_status = QD_LISTENER_ADMIN_ENABLED;
@@ -384,41 +499,68 @@ void qd_adaptor_listener_listen(qd_adaptor_listener_t *li,
     sys_mutex_lock(&li->lock);
 
     assert(li->ref_count > 0);
-    assert(!li->watched);
     assert(!li->on_accept);
+    assert(!li->reachable_address_count);
 
     li->on_accept = on_accept;
     li->user_context = context;
-    li->watched = true;
-    li->ref_count += 1;  // for watcher
-    li->addr_watcher = qdr_core_watch_address(qd_router_core(li->qd),
-                                              li->service_address,
-                                              QD_ITER_HASH_PREFIX_MOBILE,
-                                              li->qd->default_treatment,
-                                              _on_watched_address_update,
-                                              _on_watched_address_cancel,
-                                              (void*) li);
+
+    if (li->address_strategy == QD_ADDR_STRATEGY_NONE) {
+        // single address listener
+        assert(DEQ_SIZE(li->addresses) == 1);
+        qd_listener_address_t *addr = DEQ_HEAD(li->addresses);
+        li->ref_count += 1;  // for watcher
+        addr->addr_watcher = qdr_core_watch_address(qd_router_core(li->qd),
+                                                    addr->address,
+                                                    QD_ITER_HASH_PREFIX_MOBILE,
+                                                    li->qd->default_treatment,
+                                                    _on_watched_address_update,
+                                                    _on_watched_address_cancel,
+                                                    (void *) addr);
+    }
+
     sys_mutex_unlock(&li->lock);
 }
 
 
-void qd_adaptor_listener_close(qd_adaptor_listener_t *li)
+qd_error_t qd_adaptor_listener_close(qd_adaptor_listener_t *li)
 {
     if (li) {
         sys_mutex_lock(&li->lock);
+
+        if (li->address_strategy != QD_ADDR_STRATEGY_NONE && !!DEQ_SIZE(li->addresses)) {
+
+            sys_mutex_unlock(&li->lock);
+
+            return qd_error(QD_ERROR_VALUE, "listenerAddress entities exist for  multi-address listener %s", li->name);
+        }
+
         li->admin_status = QD_LISTENER_ADMIN_DELETED;
         li->oper_status = QD_LISTENER_OPER_DOWN;
         li->on_accept = 0;
         li->user_context = 0;
 
-        // Cancel the address watcher. The cancel callback will clean up the
+        // Cancel the address watchers. The last cancel callback will clean up the
         // pn_listener.
-        if (li->watched)
-            qdr_core_unwatch_address(qd_dispatch_router_core(li->qd), li->addr_watcher);
+        qd_listener_address_t *addr = DEQ_HEAD(li->addresses);
+        while (addr) {
+            // End vflow record for multi-address listener. New connection will be rejected
+            // after the listener lock is released below.
+            if (!!addr->vflow) {
+                assert(li->address_strategy != QD_ADDR_STRATEGY_NONE);
+                vflow_end_record(addr->vflow);
+                addr->vflow = 0;
+            }
+            qdr_core_unwatch_address(qd_dispatch_router_core(li->qd), addr->addr_watcher);
+            addr = DEQ_NEXT(addr);
+        }
+
         sys_mutex_unlock(&li->lock);
 
         _listener_decref(li);
     }
+
+    return QD_ERROR_NONE;
 }
 
 
@@ -451,6 +593,173 @@ void qd_adaptor_listener_deny_conn(qd_adaptor_listener_t *listener, pn_listener_
     pn_listener_raw_accept(pn_listener, close_me);
 }
 
+qd_listener_address_t *qd_adaptor_listener_best_address_incref_LH(qd_adaptor_listener_t *listener)
+{
+    //
+    //  NOTE: listener->lock is held by the caller
+    //
+
+    assert(listener->address_strategy == QD_ADDR_STRATEGY_PRIORITY);
+
+    // Addresses are ordered by priority in the address list. Find and return the first reachable one.
+    qd_listener_address_t *addr = DEQ_HEAD(listener->addresses);
+    assert(addr);
+    DEQ_FIND(addr, addr->reachable);
+
+    // Return an address even if none of them are reachable
+    if (!addr)
+        addr =  DEQ_HEAD(listener->addresses);
+
+    // ListenerAddress entity may be deleted by mgmt right after the listener lock gets released.
+    // Increase refCount for the caller.
+    sys_atomic_inc(&addr->ref_count);
+
+    return addr;
+}
+
+void *qd_adaptor_listener_add_address(qd_listener_address_config_t *config)
+{
+    qd_error_t config_error = QD_ERROR_NONE;
+
+    qd_listener_address_t *new_addr = new_qd_listener_address_t();
+    ZERO(new_addr);
+    sys_atomic_init(&new_addr->ref_count, 1);
+    new_addr->address = strdup(config->address);
+    new_addr->priority = config->value;
+
+    sys_mutex_lock(&_listeners_lock);
+    qd_adaptor_listener_t *li = DEQ_HEAD(_listeners);
+    DEQ_FIND(li, strcmp(li->name, config->listener_name) == 0);
+    sys_mutex_unlock(&_listeners_lock);
+
+    if (li) {
+        sys_mutex_lock(&li->lock);
+
+        if (li->address_strategy != QD_ADDR_STRATEGY_NONE &&
+            li->admin_status == QD_LISTENER_ADMIN_ENABLED) {
+            assert(li->ref_count > 0);
+             new_addr->listener = li;
+
+            //
+            // Insert the new address into the address list.
+            // The list is in decreasing order by priority.
+            //
+            qd_listener_address_t *addr = DEQ_HEAD(li->addresses);
+            DEQ_FIND(addr, addr->priority <= new_addr->priority);
+            if (addr) {
+                addr = DEQ_PREV(addr);
+                if (addr)
+                    DEQ_INSERT_AFTER(li->addresses, new_addr, addr);
+                else
+                    DEQ_INSERT_HEAD(li->addresses, new_addr);
+            } else {
+                 DEQ_INSERT_TAIL(li->addresses, new_addr);
+            }
+
+            //
+            // Start address watching
+            //
+            li->ref_count += 1;  // for watcher
+            new_addr->addr_watcher = qdr_core_watch_address(qd_router_core(li->qd),
+                                                            new_addr->address,
+                                                            QD_ITER_HASH_PREFIX_MOBILE,
+                                                            li->qd->default_treatment,
+                                                            _on_watched_address_update,
+                                                            _on_watched_address_cancel,
+                                                            (void *)new_addr);
+            sys_mutex_unlock(&li->lock);
+        } else {
+            sys_mutex_unlock(&li->lock);
+            if (li->address_strategy == QD_ADDR_STRATEGY_NONE) {
+                config_error = qd_error(QD_ERROR_VALUE, "Must not assign new address to non multi-address listener %s", config->listener_name);
+            } else {
+                config_error = qd_error(QD_ERROR_VALUE, "Listener for new address is being deleted %s", config->listener_name);
+            }
+        }
+    } else {
+        config_error = qd_error(QD_ERROR_VALUE, "Listener for new address does not exist %s", config->listener_name);
+    }
+
+    if (config_error == QD_ERROR_NONE) {
+        //
+        //  Create a vflow record for this listener address
+        //
+        new_addr->vflow = vflow_start_record(VFLOW_RECORD_LISTENER, 0);
+        vflow_set_string(new_addr->vflow, VFLOW_ATTRIBUTE_PROTOCOL,         "tcp");
+        vflow_set_string(new_addr->vflow, VFLOW_ATTRIBUTE_NAME,             new_addr->listener->name);
+        vflow_set_string(new_addr->vflow, VFLOW_ATTRIBUTE_DESTINATION_HOST, new_addr->listener->host);
+        vflow_set_string(new_addr->vflow, VFLOW_ATTRIBUTE_DESTINATION_PORT, new_addr->listener->port);
+        vflow_set_string(new_addr->vflow, VFLOW_ATTRIBUTE_VAN_ADDRESS,      new_addr->address);
+        vflow_set_uint64(new_addr->vflow, VFLOW_ATTRIBUTE_FLOW_COUNT_L4,    0);
+    } else {
+        // error occured
+        _listener_address_free(new_addr);
+        new_addr = 0;
+    }
+
+    return (void *)new_addr;
+}
+
+void qd_adaptor_listener_delete_address(qd_dispatch_t *qd, void *impl)
+{
+    qd_listener_address_t *address = (qd_listener_address_t *) impl;
+    if (address) {
+        qd_adaptor_listener_t *li = address->listener;
+        assert(li);
+
+        // End the vanflow record here.
+        if (address->vflow) {
+            assert(li->address_strategy != QD_ADDR_STRATEGY_NONE);
+            vflow_end_record(address->vflow);
+            address->vflow = 0;
+        }
+
+        sys_mutex_lock(&li->lock);
+
+        qdr_core_unwatch_address(qd_dispatch_router_core(li->qd), address->addr_watcher);
+
+        sys_mutex_unlock(&li->lock);
+        // address is freed  in the _on_watched_address_cancel callback
+    }
+}
+
+void qd_adaptor_listener_address_decref(qd_listener_address_t  *addr)
+{
+    if (sys_atomic_dec(&addr->ref_count) == 1) {
+        _listener_address_free(addr);
+    }
+}
+
+char *qd_adaptor_listener_address_string(qd_listener_address_t  *addr)
+{
+    return addr->address;
+}
+
+vflow_record_t *qd_adaptor_listener_address_vflow(qd_listener_address_t  *addr)
+{
+    return addr->vflow;
+}
+
+void qd_adaptor_listener_address_vflows_end(qd_adaptor_listener_t *li)
+{
+    sys_mutex_lock(&li->lock);
+    qd_listener_address_t *addr = DEQ_HEAD(li->addresses);
+    while (addr) {
+        if (addr->vflow) {
+            vflow_end_record(addr->vflow);
+            addr->vflow = 0;
+        }
+        addr = DEQ_NEXT(addr);
+    }
+    sys_mutex_unlock(&li->lock);
+}
+
+void qd_adaptor_listener_address_connection_opened(qd_listener_address_t  *addr)
+{
+    addr->connections_opened++;
+    assert(!!addr->vflow);
+    vflow_set_uint64(addr->vflow, VFLOW_ATTRIBUTE_FLOW_COUNT_L4, addr->connections_opened);
+}
 
 void qd_adaptor_listener_init(void)
 {

--- a/src/adaptors/adaptor_listener.h
+++ b/src/adaptors/adaptor_listener.h
@@ -31,6 +31,32 @@
 
 typedef struct qd_adaptor_listener_t qd_adaptor_listener_t;
 
+typedef struct qd_listener_address_t qd_listener_address_t;
+
+// Get the currently optimal listener address for a new connection and increase its refCount
+qd_listener_address_t *qd_adaptor_listener_best_address_incref_LH(qd_adaptor_listener_t *listener);
+
+// Get listener address as string
+char *qd_adaptor_listener_address_string(qd_listener_address_t *addr);
+
+// Get the vflow record of a listener address
+vflow_record_t *qd_adaptor_listener_address_vflow(qd_listener_address_t *addr);
+
+// End listener address vflow records
+void qd_adaptor_listener_address_vflows_end(qd_adaptor_listener_t *li);
+
+// Increase opened connections counter for this address
+void qd_adaptor_listener_address_connection_opened(qd_listener_address_t *addr);
+
+// Decrement the refCount of a listener address
+void qd_adaptor_listener_address_decref(qd_listener_address_t *addr);
+
+// Add a new item to the service address list of a multi-address listener
+void *qd_adaptor_listener_add_address(qd_listener_address_config_t *config);
+
+// Delete an item from service address list of a multi-address listener
+void qd_adaptor_listener_delete_address(qd_dispatch_t *qd, void *imp);
+
 // Callback invoked when a client has connected to the listener and is waiting to be accepted.  The application may
 // accept the new connection during this callback by allocating a pn_raw_connection_t and passing it to
 // pn_listener_raw_accept().  This callback may instead deny the new connection by calling
@@ -56,10 +82,11 @@ void qd_adaptor_listener_listen(qd_adaptor_listener_t *listener,
                                 void *context);
 
 // Stop listening and dispose of the listener. The caller must not reference
-// the listener again after this call. It is guaranteed that the on_accept
-// callback will never be invoked after this call returns.
-//
-void qd_adaptor_listener_close(qd_adaptor_listener_t *listener);
+// the listener again after this call if it returns no error. It is guaranteed that the on_accept
+// callback will never be invoked after this call returns without error.
+// The call returns an error if the listener cannot be deleted (e.g. a multi-address listener can only
+// be deleted after all of its addresses are deleted).
+qd_error_t qd_adaptor_listener_close(qd_adaptor_listener_t *listener);
 
 // Get the operational state of the listener
 //
@@ -74,6 +101,5 @@ char *qd_adaptor_listener_error_message(const qd_adaptor_listener_t *listener);
 // qd_adaptor_listener_accept_t callback
 //
 void qd_adaptor_listener_deny_conn(qd_adaptor_listener_t *listener, pn_listener_t *pn_listener);
-
 
 #endif // __adaptor_listener_h__

--- a/src/adaptors/tcp/tcp_adaptor.h
+++ b/src/adaptors/tcp/tcp_adaptor.h
@@ -156,6 +156,7 @@ typedef struct qd_tcp_connection_t {
         uint64_t                closed_count; // ingress: total count of window closures
         bool                    disabled;     // window flow control disabled, no backpressure allowed
     } window;
+    qd_listener_address_t      *target_address;  // target address if parent is a multi-address listener
     bool                        listener_side;
     bool                        inbound_credit;
     bool                        inbound_first_octet;
@@ -165,9 +166,11 @@ typedef struct qd_tcp_connection_t {
 
 
 QD_EXPORT void       *qd_dispatch_configure_tcp_listener(qd_dispatch_t *qd, qd_entity_t *entity);
-QD_EXPORT void        qd_dispatch_delete_tcp_listener(qd_dispatch_t *qd, void *impl);
+QD_EXPORT qd_error_t  qd_dispatch_delete_tcp_listener(qd_dispatch_t *qd, void *impl);
 QD_EXPORT qd_error_t  qd_entity_refresh_tcpListener(qd_entity_t* entity, void *impl);
+QD_EXPORT void       *qd_dispatch_configure_tcp_listener_address(qd_dispatch_t *qd, qd_entity_t *entity);
 QD_EXPORT void        qd_dispatch_delete_tcp_connector(qd_dispatch_t *qd, void *impl);
+QD_EXPORT qd_error_t  qd_entity_refresh_listenerAddress(qd_entity_t *entity, void *impl);
 QD_EXPORT qd_error_t  qd_entity_refresh_tcpConnector(qd_entity_t* entity, void *impl);
 qd_tcp_connector_t *qd_dispatch_configure_tcp_connector(qd_dispatch_t *qd, qd_entity_t *entity);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,6 +167,7 @@ foreach(py_test_module
     system_tests_tcp_adaptor
     system_tests_tcp_adaptor_tls
     system_tests_tcp_conns_terminate
+    system_tests_tcp_multi_address_listener
     system_tests_address_watch
     system_tests_router_annotations
     system_tests_vflow

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -97,6 +97,7 @@ ROUTER_METRICS_TYPE = 'io.skupper.router.routerMetrics'
 SSL_PROFILE_TYPE = 'io.skupper.router.sslProfile'
 TCP_CONNECTOR_TYPE = 'io.skupper.router.tcpConnector'
 TCP_LISTENER_TYPE = 'io.skupper.router.tcpListener'
+LISTENER_ADDRESS_TYPE = 'io.skupper.router.listenerAddress'
 
 # The directory where this module lives. Used to locate static configuration files etc.
 DIR = os.path.dirname(__file__)
@@ -832,7 +833,7 @@ class Qdrouterd(Process):
         try:
             if self.sk_manager:
                 # Delete all adaptor connectors and listeners before shutting down the router
-                long_types = [TCP_LISTENER_TYPE, TCP_CONNECTOR_TYPE]
+                long_types = [LISTENER_ADDRESS_TYPE, TCP_LISTENER_TYPE, TCP_CONNECTOR_TYPE]
                 for long_type in long_types:
                     self.sk_manager.delete_all_entities(long_type)
                 retry_assertion(self.sk_manager.delete_adaptor_connections)

--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -631,9 +631,11 @@ class RouterConfigTest(TestCase):
         # a short timeout is OK since the router has exited the outfile is
         # completely written!
 
-        err = r"Router start-up failed: Python: .* KeyError: \(?'address'"
-        for index in [10, 11]:
-            self.routers[index].wait_log_message(err, timeout=1.0)
+        err = "Router start-up failed: Python: CError: Configuration: Address must be set"
+        self.routers[10].wait_log_message(err, timeout=1.0)
+
+        err = "Router start-up failed: Python: CError: Configuration: Exactly one of the 'address' or 'multiAddressStrategy' field must be set"
+        self.routers[11].wait_log_message(err, timeout=1.0)
 
         err = "sslProfile 'DoesNotExist' not found"
         self.routers[12].wait_log_message(err, timeout=1.0)

--- a/tests/system_tests_skmanage.py
+++ b/tests/system_tests_skmanage.py
@@ -38,7 +38,7 @@ from system_test import CA_CERT, SERVER_CERTIFICATE, SERVER_PRIVATE_KEY, SERVER_
     CLIENT_CERTIFICATE, CLIENT_PASSWORD_FILE, CLIENT_PRIVATE_KEY
 CONNECTION_PROPERTIES_UNICODE_STRING = {'connection': 'properties', 'int_property': 6451}
 
-TOTAL_ENTITIES = 29   # for tests that check the total # of entities
+TOTAL_ENTITIES = 30   # for tests that check the total # of entities
 
 
 class SkmanageTest(TestCase):

--- a/tests/system_tests_tcp_multi_address_listener.py
+++ b/tests/system_tests_tcp_multi_address_listener.py
@@ -1,0 +1,518 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
+
+import json
+import os
+import shutil
+import subprocess
+
+from system_test import TestCase, Qdrouterd, retry, retry_assertion
+from system_test import Logger
+from vanflow_snooper import VFlowSnooperThread, ANY_VALUE
+from TCP_echo_client import TcpEchoClient
+from TCP_echo_server import TcpEchoServer
+
+
+class MultiAddressListenerTest(TestCase):
+    """
+    Test for the multi address listener. Two routers are run. The first one has a multi address listener
+    configured at startup. Four distinct service addresses are created for the listener. Each address targets a
+    separate tcpConnector which in turn connects to a separate echo server. The test uses a vanflow snooper thread
+    to check if the correct connection flow got exercised under the specific configuration. Possible flows are
+    as follows.
+    addr1 -> connector_1
+    addr2 -> connector_2
+    addr3 -? connector_3
+    addr4 -? connector_4
+    The test create and delete listener addresses and tcpConnecters. It launches an echo client after each
+    configuration change to check if new tcp connections target the expected tcpConnecter.
+    """
+
+    @classmethod
+    def findNewFlowId(cls, entity_type, entity_name, van_address=None, sources=None):
+        def findIdOnce(sources):
+            flow_id = None
+            for _, records in sources.items():
+                for rec in records:
+                    if (rec['RECORD_TYPE'] == entity_type and rec['NAME'] == entity_name and rec['VAN_ADDRESS'] == van_address and rec['FLOW_COUNT_L4'] == 0):
+                        return rec['IDENTITY']
+            return None
+
+        def findIdRepeat():
+            sources = cls.snooper_thread.get_results()
+            return findIdOnce(sources)
+
+        if sources is not None:
+            return findIdOnce(sources)
+        else:
+            return retry(findIdRepeat)
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Start two routers: R1 and R2. Both have two tcpConnectors with two TCP echo
+        server attached. Both router also  has four tcpListeners. One of the
+        tcpConnectors and two of the tcpListeners are using SSL at both routers.
+        The new config flag is tuned on for R1 but not for R2.
+        Each tcpConnector has a unique VAN address which is also used by one tcpListener
+        at each router. The four distinct VAN addresses are used to test deletion of a
+        tcpListeners and tcpConnectors with ot without using SSL.
+        """
+        super(MultiAddressListenerTest, cls).setUpClass()
+
+        cls.test_name = 'MultiAddressListenerTest'
+
+        router_1_id = 'R1'
+        router_2_id = 'R2'
+
+        # VAN addresses
+        cls.van_address = [cls.test_name + '_addr_1',
+                           cls.test_name + '_addr_2',
+                           cls.test_name + '_addr_3',
+                           cls.test_name + '_addr_4']
+        # listener addresses
+        cls.listener_address_name =     ['addr1', 'addr2', 'addr3', 'addr4']
+        cls.listener_address_priority = ['10',    '20',    '5',     '15']
+        cls.listener_address_startup =  [True,    True,    False,   False]
+        # Listener
+        cls.listener_name = 'listener_multi_1'
+        cls.listener_port = cls.tester.get_port()
+        # Connectors
+        cls.connector_name = ['connector_1', 'connector_2', 'connector_3', 'connector_4']
+
+        # Launch TCP echo servers
+        server_logger = Logger(title=cls.test_name,
+                               print_to_console=True,
+                               save_for_dump=False,
+                               ofilename=os.path.join(os.path.dirname(os.getcwd()),
+                                                      f"{cls.test_name}_echo_server.log"))
+        echo_servers = {}
+        server_prefix = f"{cls.test_name} ECHO_SERVER_addr_1"
+        echo_servers[cls.van_address[0]] = TcpEchoServer(prefix=server_prefix, port=0, logger=server_logger)
+        assert echo_servers[cls.van_address[0]].is_running
+        server_prefix = f"{cls.test_name} ECHO_SERVER_addr_2"
+        echo_servers[cls.van_address[1]] = TcpEchoServer(prefix=server_prefix, port=0, logger=server_logger)
+        assert echo_servers[cls.van_address[1]].is_running
+        server_prefix = f"{cls.test_name} ECHO_SERVER_addr_3"
+        echo_servers[cls.van_address[2]] = TcpEchoServer(prefix=server_prefix, port=0, logger=server_logger)
+        assert echo_servers[cls.van_address[2]].is_running
+        server_prefix = f"{cls.test_name} ECHO_SERVER_addr_4"
+        echo_servers[cls.van_address[3]] = TcpEchoServer(prefix=server_prefix, port=0, logger=server_logger)
+        assert echo_servers[cls.van_address[3]].is_running
+
+        cls.echo_servers = echo_servers
+
+        # listener config
+        cls.listener_config = [
+            ('tcpListener', {'host': "0.0.0.0",
+                             'port': cls.listener_port,
+                             'multiAddressStrategy': "priority",
+                             'name': cls.listener_name})]
+
+        # listener address config
+        cls.listener_address_config = [
+            ('listenerAddress', {'name': cls.listener_address_name[0],
+                                 'value': cls.listener_address_priority[0],
+                                 'address': cls.van_address[0],
+                                 'listener': cls.listener_name}),
+            ('listenerAddress', {'name': cls.listener_address_name[1],
+                                 'value': cls.listener_address_priority[1],
+                                 'address': cls.van_address[1],
+                                 'listener': cls.listener_name}),
+            ('listenerAddress', {'name': cls.listener_address_name[2],
+                                 'value': cls.listener_address_priority[2],
+                                 'address': cls.van_address[2],
+                                 'listener': cls.listener_name}),
+            ('listenerAddress', {'name': cls.listener_address_name[3],
+                                 'value': cls.listener_address_priority[3],
+                                 'address': cls.van_address[3],
+                                 'listener': cls.listener_name})]
+
+        # tcp connector configs
+        cls.connector_config = [
+            ('tcpConnector', {'host': "localhost",
+                              'address': cls.van_address[0],
+                              'port': echo_servers[cls.van_address[0]].port,
+                              'name': cls.connector_name[0]}),
+            ('tcpConnector', {'host': "localhost",
+                              'address': cls.van_address[1],
+                              'port': echo_servers[cls.van_address[1]].port,
+                              'name': cls.connector_name[1]}),
+            ('tcpConnector', {'host': "localhost",
+                              'address': cls.van_address[2],
+                              'port': echo_servers[cls.van_address[2]].port,
+                              'name': cls.connector_name[2]}),
+            ('tcpConnector', {'host': "localhost",
+                              'address': cls.van_address[3],
+                              'port': echo_servers[cls.van_address[3]].port,
+                              'name': cls.connector_name[3]})
+        ]
+
+        # Launch routers
+        inter_router_port = cls.tester.get_port()
+        config_1 = Qdrouterd.Config([
+            ('router', {'mode': 'interior', 'id': router_1_id}),
+            ('listener', {'port': cls.tester.get_port()}),
+            ('connector', {'role': 'inter-router', 'port': inter_router_port}),
+            cls.listener_config[0],
+            cls.listener_address_config[0],
+            cls.listener_address_config[1],
+            cls.connector_config[0]
+        ])
+        config_2 = Qdrouterd.Config([
+            ('router', {'mode': 'interior', 'id': router_2_id}),
+            ('listener', {'port': cls.tester.get_port()}),
+            ('listener', {'role': 'inter-router', 'port': inter_router_port}),
+            cls.connector_config[1],
+            cls.connector_config[2],
+            cls.connector_config[3]
+        ])
+
+        cls.router_2 = cls.tester.qdrouterd('test_router_2', config_2)
+        cls.router_1 = cls.tester.qdrouterd('test_router_1', config_1)
+
+        cls.router_1.wait_router_connected('R2')
+        cls.router_2.wait_router_connected('R1')
+
+        cls.snooper_thread = VFlowSnooperThread(cls.router_1.addresses[0])
+
+        # Wait for the TCP connectors and listeners
+        expected = {
+            router_1_id : [
+                ('CONNECTOR', {'NAME': cls.connector_name[0], 'VAN_ADDRESS': cls.van_address[0]},
+                 'LISTENER', {'NAME': cls.listener_name, 'VAN_ADDRESS': cls.van_address[0]},
+                 'LISTENER', {'NAME': cls.listener_name, 'VAN_ADDRESS': cls.van_address[1]})
+            ],
+            router_2_id : [
+                ('CONNECTOR', {'NAME': cls.connector_name[1], 'VAN_ADDRESS': cls.van_address[1]}),
+                ('CONNECTOR', {'NAME': cls.connector_name[2], 'VAN_ADDRESS': cls.van_address[2]}),
+                ('CONNECTOR', {'NAME': cls.connector_name[3], 'VAN_ADDRESS': cls.van_address[3]})
+            ]
+        }
+
+        # Save the status of this check to avoid calling assert() in the ctor
+        cls.tcp_entities_ready = retry(lambda: cls.snooper_thread.match_records(expected))
+        vflow_records = cls.snooper_thread.get_results()
+
+        if cls.tcp_entities_ready:
+            # vflow ids are necessary to relate flows to tcp listeners and connectors
+            # Note that a multi-address listener create as many vflow records of type LISTENER as many address it has.
+            # All those LISTENER records share the same name.
+            cls.connector_vflow_id = {}
+            cls.listener_vflow_id = {}
+            for i, aname in enumerate(cls.listener_address_name):
+                if cls.listener_address_startup[i]:
+                    cls.listener_vflow_id[aname] = cls.findNewFlowId('LISTENER', cls.listener_name, cls.van_address[i], vflow_records)
+            for i, cname in enumerate(cls.connector_name):
+                cls.connector_vflow_id[cname] = cls.findNewFlowId('CONNECTOR', cname, cls.van_address[i], vflow_records)
+        cls.setup_vflow_records = vflow_records
+
+        # L4 flow counts for listener and connector vflow records
+        cls.flow_count_l4 = {}
+        # BIFLOW_TPORT records match history. It is needed to match new instances of flow records referencing the same
+        # listener and connector vflow ids.
+        cls.matched_biflow_tport_records = {}
+
+        # Generix info messages
+        cls.logger = Logger(title=cls.test_name, print_to_console=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        # stop echo servers
+        for _, server in cls.echo_servers.items():
+            server.wait()
+        super(MultiAddressListenerTest, cls).tearDownClass()
+
+    def check_setup_status(self):
+        self.assertTrue(self.tcp_entities_ready, f"Match failed: {self.setup_vflow_records}")
+        for i, aname in enumerate(self.listener_address_name):
+            if self.listener_address_startup[i]:
+                self.assertIsNotNone(self.listener_vflow_id[aname])
+        for cname in self.connector_name:
+            self.assertIsNotNone(self.connector_vflow_id[cname])
+
+    def find_entity(self, entity_type, entity_name, router, expected=True):
+        query_cmd = f'QUERY --type={entity_type}'
+        output = json.loads(router.sk_manager(query_cmd))
+        res = [e for e in output if e['name'] == entity_name]
+        if expected:
+            self.assertTrue(len(res) == 1)
+            return res[0]
+        else:
+            self.assertTrue(len(res) == 0)
+        return None
+
+    def delete_entity(self, entity_type, entity_name, router):
+        delete_cmd = 'DELETE --type=' + entity_type + ' --name=' + entity_name
+        router.sk_manager(delete_cmd)
+        # check that the entity has been deleted
+        retry_assertion(lambda: self.find_entity(entity_type, entity_name, router, expected=False), delay=0.5)
+
+    def create_entity(self, entity_name, entity_config, router):
+        entity_type = entity_config[0]
+        create_cmd = f"CREATE --type={entity_type}"
+        for k, v in entity_config[1].items():
+            create_cmd += f" {k}={v}"
+        router.sk_manager(create_cmd)
+        # check that the entity has been created
+        retry_assertion(lambda: self.find_entity(entity_type, entity_name, router))
+
+    def is_listener_port_closed(self):
+        cmd = shutil.which("lsof")
+        if cmd is None:
+            self.logger.log("(INFO) Skipping listening port check because 'lsof' command is not available")
+            return None
+
+        def check_port():
+            try:
+                res = subprocess.run([cmd, "-nP", f"-iTCP:{self.listener_port}", "-sTCP:LISTEN"],
+                                     stdout=subprocess.DEVNULL, check=True)
+            except subprocess.CalledProcessError:
+                return True
+            return res.returncode != 0
+
+        return retry(check_port, delay=0.1)
+
+    def create_echo_client(self, client_prefix, client_port):
+        # There may be a delay before address watch marks a listener address unreachable
+        # when the corresponding tcpConnector is deleted. We use the retry() function to re-launch
+        # echo client when the client gets stuck trying to send via the tcpConnector already
+        # closed. This manifest as a "server closed" exception when we call the client wait()
+        # function.
+        client_logger = Logger(title=client_prefix,
+                               print_to_console=True)
+
+        def echo_client():
+            try:
+                client = TcpEchoClient(client_prefix,
+                                       host='localhost',
+                                       port=client_port,
+                                       size=1,
+                                       count=1,
+                                       logger=client_logger,
+                                       delay_close=True)
+                client.wait()
+            except Exception as e:
+                if "server closed" in str(e):
+                    return False
+                raise
+            return True
+
+        retry(echo_client, delay=0.2)
+
+    def check_biflow_tport_vflow_record(self, router_id, listener_vflow_id, connector_vflow_id):
+        """
+        Check if BIFLOW_TPORT vflow record for the specific listener and connector
+        """
+
+        # Add the new expected record description to the ones that have been matched already (in previous calls
+        # to this function). This is needed to match the exact number of BIFLOW_TPORT records referencing the same
+        # listener and connector vflow ids.
+        expected = self.matched_biflow_tport_records
+        if expected.get(router_id) is None:
+            expected[router_id] = []
+
+        expected[router_id].append(('BIFLOW_TPORT', {'PARENT': listener_vflow_id, 'END_TIME': ANY_VALUE, 'CONNECTOR': connector_vflow_id}))
+        success = retry(lambda: self.snooper_thread.match_records(expected))
+        self.assertTrue(success,
+                        f"Listener vflowId {listener_vflow_id} Matched records {self.snooper_thread.get_results()}")
+        # increase L4 flow counts
+        for vflow_id in [listener_vflow_id, connector_vflow_id]:
+            if self.flow_count_l4.get(vflow_id) is not None:
+                self.flow_count_l4[vflow_id] += 1
+            else:
+                self.flow_count_l4[vflow_id] = 1
+
+    def check_entity_vflow_record_end(self, router_id, record_type, entity_vflow_id, flow_count_l4):
+        """
+        Check if the end vflow record exists for the specific entity
+        """
+        expected = {
+            router_id: [
+                (record_type, {'IDENTITY': entity_vflow_id, 'END_TIME': ANY_VALUE, 'FLOW_COUNT_L4': flow_count_l4})
+            ]
+        }
+        success = retry(lambda: self.snooper_thread.match_records(expected))
+        self.assertTrue(success,
+                        f"Router vflowId {router_id} entity vflowId {entity_vflow_id} RECORDS: {self.snooper_thread.get_results()}")
+
+    def check_flow(self, flow_index, echo_client_name):
+        client_prefix = self.test_name + echo_client_name +  self.van_address[flow_index]
+        self.create_echo_client(client_prefix, self.listener_port)
+        connector_vflow_id = self.connector_vflow_id[self.connector_name[flow_index]]
+        listener_vflow_id = self.listener_vflow_id[self.listener_address_name[flow_index]]
+        router_1_id = self.router_1.config.router_id
+        self.check_biflow_tport_vflow_record(router_1_id, listener_vflow_id, connector_vflow_id)
+
+    def test_multi_address_listener(self):
+        self.check_setup_status()  # throw here if something failed in setUp()
+
+        router_1_id = self.router_1.config.router_id
+        router_2_id = self.router_2.config.router_id
+
+        # addr2:(prio=20, reachable:True)
+        # addr1:(prio=10, reachable:True)
+        # check flow: listener addr2 -> connector_2 (flow index 1)
+        flow_index = 1
+        client_name = "ECHO_CLIENT_1_"
+        self.check_flow(flow_index, client_name)
+
+        # delete addr2
+        self.delete_entity('listenerAddress', self.listener_address_name[1], self.router_1)
+        # addr1:(prio=10, reachable:True)
+        # check flow: listener addr1 -> connector_1 (flow index 0)
+        flow_index = 0
+        client_name = "ECHO_CLIENT_2_"
+        self.check_flow(flow_index, client_name)
+
+        # delete addr1
+        self.delete_entity('listenerAddress', self.listener_address_name[0], self.router_1)
+        # no listener address
+        # check that listener socket is closed
+        ret = self.is_listener_port_closed()
+        if ret is not None:
+            self.assertTrue(ret)
+
+        # re-create addr1
+        self.create_entity(self.listener_address_name[0], self.listener_address_config[0], self.router_1)
+        self.listener_vflow_id[self.listener_address_name[0]] = self.findNewFlowId('LISTENER',
+                                                                                   self.listener_name,
+                                                                                   self.van_address[0])
+        self.assertIsNotNone(self.listener_vflow_id[self.listener_address_name[0]])
+        # addr1:(prio=10, reachable:True)
+        # check flow: listener addr1 -> connector_1 (flow index 0)
+        flow_index = 0
+        client_name = "ECHO_CLIENT_3_"
+        self.check_flow(flow_index, client_name)
+
+        # re-create addr2
+        self.create_entity(self.listener_address_name[1], self.listener_address_config[1], self.router_1)
+        self.listener_vflow_id[self.listener_address_name[1]] = self.findNewFlowId('LISTENER',
+                                                                                   self.listener_name,
+                                                                                   self.van_address[1])
+        self.assertIsNotNone(self.listener_vflow_id[self.listener_address_name[1]])
+        # addr2:(prio=20, reachable:True)
+        # addr1:(prio=10, reachable:True)
+        # check flow: listener addr2 -> connector_2 (flow index 1)
+        flow_index = 1
+        client_name = "ECHO_CLIENT_4_"
+        self.check_flow(flow_index, client_name)
+
+        # create addr3
+        self.create_entity(self.listener_address_name[2], self.listener_address_config[2], self.router_1)
+        self.listener_vflow_id[self.listener_address_name[2]] = self.findNewFlowId('LISTENER',
+                                                                                   self.listener_name,
+                                                                                   self.van_address[2])
+        self.assertIsNotNone(self.listener_vflow_id[self.listener_address_name[2]])
+        # addr2:(prio=20, reachable:True)
+        # addr1:(prio=10, reachable:True)
+        # addr3:(prio=5,  reachable:True)
+        # check flow: listener addr2 -> connector_2 (flow index 1)
+        flow_index = 1
+        client_name = "ECHO_CLIENT_5_"
+        self.check_flow(flow_index, client_name)
+
+        # create addr4
+        self.create_entity(self.listener_address_name[3], self.listener_address_config[3], self.router_1)
+        self.listener_vflow_id[self.listener_address_name[3]] = self.findNewFlowId('LISTENER',
+                                                                                   self.listener_name,
+                                                                                   self.van_address[3])
+        self.assertIsNotNone(self.listener_vflow_id[self.listener_address_name[3]])
+        # addr2:(prio=20, reachable:True)
+        # addr4:(prio=15, reachable:True)
+        # addr1:(prio=10, reachable:True)
+        # addr3:(prio=5,  reachable:True)
+        # check flow: listener addr2 -> connector_2 (flow index 1)
+        flow_index = 1
+        client_name = "ECHO_CLIENT_6_"
+        self.check_flow(flow_index, client_name)
+
+        # delete connector_2
+        self.delete_entity('tcpConnector', self.connector_name[1], self.router_2)
+        # wait until connector END vflow record gets propagated to the vanflow snooper at router_1
+        connector_vflow_id = self.connector_vflow_id[self.connector_name[1]]
+        flow_count_l4 = self.flow_count_l4[connector_vflow_id] + 1
+        self.check_entity_vflow_record_end(router_2_id, 'CONNECTOR', connector_vflow_id, flow_count_l4)
+        # addr2:(prio=20, reachable:False)
+        # addr4:(prio=15, reachable:True)
+        # addr1:(prio=10, reachable:True)
+        # addr3:(prio=5,  reachable:True)
+        # check flow: listener addr4 -> connector_4 (flow index 3)
+        flow_index = 3
+        client_name = "ECHO_CLIENT_7_"
+        self.check_flow(flow_index, client_name)
+
+        # delete connector_1
+        self.delete_entity('tcpConnector', self.connector_name[0], self.router_1)
+        # wait until connector END vflow record gets propagated to the vanflow snooper at router_1
+        connector_vflow_id = self.connector_vflow_id[self.connector_name[0]]
+        flow_count_l4 = self.flow_count_l4[connector_vflow_id] + 1
+        self.check_entity_vflow_record_end(router_1_id, 'CONNECTOR', connector_vflow_id, flow_count_l4)
+        # addr2:(prio=20, reachable:False)
+        # addr4:(prio=15, reachable:True)
+        # addr1:(prio=10, reachable:False)
+        # addr3:(prio=5,  reachable:True)
+        # check flow: listener addr4 -> connector_4 (flow index 3)
+        flow_index = 3
+        client_name = "ECHO_CLIENT_8_"
+        self.check_flow(flow_index, client_name)
+
+        # delete connector_4
+        self.delete_entity('tcpConnector', self.connector_name[3], self.router_2)
+        # wait until connector END vflow record gets propagated to the vanflow snooper at router_1
+        connector_vflow_id = self.connector_vflow_id[self.connector_name[3]]
+        flow_count_l4 = self.flow_count_l4[connector_vflow_id] + 1
+        self.check_entity_vflow_record_end(router_2_id, 'CONNECTOR', connector_vflow_id, flow_count_l4)
+        # addr2:(prio=20, reachable:False)
+        # addr4:(prio=15, reachable:False)
+        # addr1:(prio=10, reachable:False)
+        # addr3:(prio=5,  reachable:True)
+        # check flow: listener addr3 -> connector_3 (flow index 2)
+        flow_index = 2
+        client_name = "ECHO_CLIENT_9_"
+        self.check_flow(flow_index, client_name)
+
+        # delete connector_3
+        self.delete_entity('tcpConnector', self.connector_name[2], self.router_2)
+        # wait until connector END vflow record gets propagated to the vanflow snooper at router_1
+        connector_vflow_id = self.connector_vflow_id[self.connector_name[2]]
+        flow_count_l4 = self.flow_count_l4[connector_vflow_id] + 1
+        self.check_entity_vflow_record_end(router_2_id, 'CONNECTOR', connector_vflow_id, flow_count_l4)
+        # addr2:(prio=20, reachable:False)
+        # addr4:(prio=15, reachable:False)
+        # addr1:(prio=10, reachable:False)
+        # addr3:(prio=5,  reachable:False)
+        # check that listening socket got closed
+        ret = self.is_listener_port_closed()
+        if ret is not None:
+            self.assertTrue(ret)
+
+        # re-create connector_1 at router_2
+        self.create_entity(self.connector_name[0], self.connector_config[0], self.router_2)
+        self.connector_vflow_id[self.connector_name[0]] = self.findNewFlowId('CONNECTOR',
+                                                                             self.connector_name[0],
+                                                                             self.van_address[0])
+        # addr2:(prio=20, reachable:False)
+        # addr4:(prio=15, reachable:False)
+        # addr1:(prio=10, reachable:True)
+        # addr3:(prio=5,  reachable:False)
+        # check flow: listener addr1 -> connector_1 (flow index 0)
+        flow_index = 0
+        client_name = "ECHO_CLIENT_10_"
+        self.check_flow(flow_index, client_name)


### PR DESCRIPTION
Fixes issue issues #1813 and #1814

Add support for multi-routing-key listeners. 

- Extend tcpListener entity witth a multiAddressStrategy field
- Add new entity type ListenerAddress to the management scheme
- Add configure and delete management  APIs to the ListenerAddress entity
-  Modify adaptor_listener  and tcp_listener C files to use a service address list 

