### PR TITLE
Fix container image build for tar 1.34-8+

### DIFF
--- a/.github/scripts/compile.sh
+++ b/.github/scripts/compile.sh
@@ -37,12 +37,14 @@ if [ -z "${REMOTE_SOURCES_DIR:-}" ]; then
   # and untar it into the libwebsockets folder
   wget "${LWS_SOURCE_URL}" -O libwebsockets.tar.gz
   wget "${LIBUNWIND_SOURCE_URL}" -O libunwind.tar.gz
-  tar -zxf libwebsockets.tar.gz --one-top-level="${LWS_DIR}"       --strip-components 1
-  tar -zxf libunwind.tar.gz     --one-top-level="${LIBUNWIND_DIR}" --strip-components 1
+  mkdir -p "${LWS_DIR}" "${LIBUNWIND_DIR}"
+  tar -zxf libwebsockets.tar.gz -C "${LWS_DIR}" --strip-components 1
+  tar -zxf libunwind.tar.gz -C "${LIBUNWIND_DIR}" --strip-components 1
 
   # No $REMOTE_SOURCES_DIR was provided, we will have to download the proton source tar.gz from ${PROTON_SOURCE_URL}
   wget "${PROTON_SOURCE_URL}" -O qpid-proton.tar.gz
-  tar -zxf qpid-proton.tar.gz --one-top-level="${PROTON_DIR}" --strip-components 1
+  mkdir -p "${PROTON_DIR}"
+  tar -zxf qpid-proton.tar.gz -C "${PROTON_DIR}" --strip-components 1
 else
   # If the env contains REMOTE_SOURCES_DIR, we will use that as the working dir
   # If REMOTE_SOURCES_DIR is provided, this scripts expects the following -

--- a/Containerfile
+++ b/Containerfile
@@ -49,10 +49,10 @@ ENV VERSION=$VERSION
 ARG TARGETARCH
 ENV PLATFORM=$TARGETARCH
 RUN .github/scripts/compile.sh
-RUN if [ "$PLATFORM" = "amd64" ]; then tar zxpf /qpid-proton-image.tar.gz --one-top-level=/image && tar zxpf /skupper-router-image.tar.gz --one-top-level=/image && tar zxpf /libwebsockets-image.tar.gz --one-top-level=/image && tar zxpf /libunwind-image.tar.gz --one-top-level=/image; fi
-RUN if [ "$PLATFORM" = "arm64" ]; then tar zxpf /qpid-proton-image.tar.gz --one-top-level=/image && tar zxpf /skupper-router-image.tar.gz --one-top-level=/image && tar zxpf /libwebsockets-image.tar.gz --one-top-level=/image; fi
-RUN if [ "$PLATFORM" = "s390x" ]; then tar zxpf /qpid-proton-image.tar.gz --one-top-level=/image && tar zxpf /skupper-router-image.tar.gz --one-top-level=/image && tar zxpf /libwebsockets-image.tar.gz --one-top-level=/image; fi
-RUN if [ "$PLATFORM" = "ppc64le" ]; then tar zxpf /qpid-proton-image.tar.gz --one-top-level=/image && tar zxpf /skupper-router-image.tar.gz --one-top-level=/image && tar zxpf /libwebsockets-image.tar.gz --one-top-level=/image; fi
+RUN mkdir -p /image && if [ "$PLATFORM" = "amd64" ]; then tar zxpf /qpid-proton-image.tar.gz -C /image && tar zxpf /skupper-router-image.tar.gz -C /image && tar zxpf /libwebsockets-image.tar.gz -C /image && tar zxpf /libunwind-image.tar.gz -C /image; fi
+RUN if [ "$PLATFORM" = "arm64" ]; then tar zxpf /qpid-proton-image.tar.gz -C /image && tar zxpf /skupper-router-image.tar.gz -C /image && tar zxpf /libwebsockets-image.tar.gz -C /image; fi
+RUN if [ "$PLATFORM" = "s390x" ]; then tar zxpf /qpid-proton-image.tar.gz -C /image && tar zxpf /skupper-router-image.tar.gz -C /image && tar zxpf /libwebsockets-image.tar.gz -C /image; fi
+RUN if [ "$PLATFORM" = "ppc64le" ]; then tar zxpf /qpid-proton-image.tar.gz -C /image && tar zxpf /skupper-router-image.tar.gz -C /image && tar zxpf /libwebsockets-image.tar.gz -C /image; fi
 
 RUN mkdir /image/licenses && cp ./LICENSE /image/licenses
 


### PR DESCRIPTION
Replace tar --one-top-level with -C flag to work around a regression in RHEL/UBI's tar package. Issue ref: https://issues.redhat.com/browse/RHEL-143906

Fixes container image build errors for an "Invalid cross-device link".