### PR TITLE
Specify address and port attributes as requried

### DIFF
--- a/python/skupper_router/management/skrouter.json
+++ b/python/skupper_router/management/skrouter.json
@@ -1089,6 +1089,7 @@
                 "address": {
                     "description":"Address of this bridge",
                     "type": "string",
+                    "required": true,
                     "create": true
                 },
                 "host": {
@@ -1107,6 +1108,7 @@
                 "port": {
                     "description": "Port number or symbolic service name.  If '0', the router shall assign an ephemeral port to the listener and log the port number with a log of the form 'SERVER (info) Listening on <host>:<assigned-port> (<listener-name>)'",
                     "type": "string",
+                    "required": true,
                     "create": true
                 },
                 "siteId": {
@@ -1175,6 +1177,7 @@
                 "address": {
                     "description":"Address of this bridge",
                     "type": "string",
+                    "required": true,
                     "create": true
                 },
                 "host": {
@@ -1186,6 +1189,7 @@
                 "port": {
                     "description": "Port number or symbolic service name.",
                     "type": "string",
+                    "required": true,
                     "create": true
                 },
                 "siteId": {

--- a/python/skupper_router_internal/management/agent.py
+++ b/python/skupper_router_internal/management/agent.py
@@ -378,9 +378,10 @@ class VhostStatsEntity(EntityAdapter):
 
 
 def _host_port_name_identifier(entity):
-    for attr in ['host', 'name']:  # Set default values if need be
-        entity.attributes.setdefault(
-            attr, entity.entity_type.attribute(attr).missing_value())
+    for attr in ['host', 'port', 'name']:  # Set default values if need be
+        if attr not in entity.attributes:
+            attr_type = entity.entity_type.attribute(attr)
+            entity.attributes[attr] = attr_type.missing_value()
 
     if entity.attributes.get('name'):
         return "%s:%s:%s" % (entity.attributes['host'], entity.attributes['port'], entity.attributes['name'])

--- a/python/skupper_router_internal/management/agent.py
+++ b/python/skupper_router_internal/management/agent.py
@@ -378,7 +378,7 @@ class VhostStatsEntity(EntityAdapter):
 
 
 def _host_port_name_identifier(entity):
-    for attr in ['host', 'port', 'name']:  # Set default values if need be
+    for attr in ['host', 'name']:  # Set default values if need be
         entity.attributes.setdefault(
             attr, entity.entity_type.attribute(attr).missing_value())
 

--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -625,15 +625,28 @@ class RouterConfigTest(TestCase):
                 if error_string in line:
                     test_pass = True
                     break
+        self.assertTrue(test_pass)
 
+        error_string = "io.skupper.router.tcpConnector: Missing required attribute 'address'"
+        test_pass = False
+        with open(self.routers[10].outfile + '.out', 'r') as out_file:
+            for line in out_file:
+                if error_string in line:
+                    test_pass = True
+                    break
+        self.assertTrue(test_pass)
+
+        error_string = "io.skupper.router.tcpListener: Missing required attribute 'address'"
+        test_pass = False
+        with open(self.routers[11].outfile + '.out', 'r') as out_file:
+            for line in out_file:
+                if error_string in line:
+                    test_pass = True
+                    break
         self.assertTrue(test_pass)
 
         # a short timeout is OK since the router has exited the outfile is
         # completely written!
-
-        err = r"Router start-up failed: Python: .* KeyError: \(?'address'"
-        for index in [10, 11]:
-            self.routers[index].wait_log_message(err, timeout=1.0)
 
         err = "sslProfile 'DoesNotExist' not found"
         self.routers[12].wait_log_message(err, timeout=1.0)


### PR DESCRIPTION
Sets required=true for the address and port attributes on the tcp adaptors: tcpListener and tcpConnector. These attributes have always been required by the implementation but have ben underspecified in the spec document until now.

Fixes https://github.com/skupperproject/skupper-router/issues/1848 