### PR TITLE
Fix clang-analyzer workflow

### DIFF
--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -71,10 +71,15 @@ jobs:
     - name: Delete Proton
       run: rm -rf qpid-proton
 
+      # To make sure that pip can upgrade typing-extensions
+    - name: Prepare compilation database
+      run: sudo apt remove -y python3-typing-extensions
+      continue-on-error: true
+
     # https://clang-analyzer.llvm.org/command-line.html
     - name: Create compilation database
       run: |
-        PIP_BREAK_SYSTEM_PACKAGES=1 sudo pip3 install codechecker
+        PIP_BREAK_SYSTEM_PACKAGES=1 sudo --preserve-env=PIP_BREAK_SYSTEM_PACKAGES pip3 install codechecker
         # disable IPO to make compilation faster
         cmake -S . -B build -DBUILD_TESTING=OFF -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DQD_ENABLE_ASSERTIONS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_WARNING_ERROR=OFF
         # perform build so that generated sources get generated


### PR DESCRIPTION
- pip cannot upgrade typing-extensions module if an older version is installed from a deb package
- make 'sudo' pick-up the PIP_BREAK_SYSTEM_PACKAGES env var

Fixes #1859